### PR TITLE
Unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+GTEST_DIR=googletest/googletest
+
 # Name of the executable
 TARGET=webserver
 
@@ -13,7 +15,19 @@ SRC=main.cc server.cc config_parser.cc http_response.cc
 $(TARGET): clean
 	$(CXX) -o $@ $(SRC) $(CXXFLAGS) $(LDFLAGS)
 
-.PHONY: clean
+.PHONY: clean test 
+
 clean:
 	$(RM) $(TARGET) $(OBJS)
 
+test_setup: 
+	g++ -std=c++11 -isystem ${GTEST_DIR}/include -I${GTEST_DIR} -pthread -c ${GTEST_DIR}/src/gtest-all.cc; \
+	ar -rv libgtest.a gtest-all.o;
+
+test: test_setup config_parser_test
+
+config_parser_test: test_setup config_parser.cc config_parser_test.cc
+	g++ -std=c++11 -isystem ${GTEST_DIR}/include -pthread config_parser_test.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o config_parser_test
+
+http_response_test: test_setup
+	g++ -std=c++11 -isystem ${GTEST_DIR}/include -pthread http_response_test.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o http_response_test $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CXXFLAGS+=-std=c++11 -Wall -Werror
 LDFLAGS+=-lboost_system
 
 # Source files
-SRC=main.cc server.cc config_parser.cc http_response.cc
+SRC=main.cc server.cc config_parser.cc http_response.cc server_config_parser.cc
 
 $(TARGET): clean
 	$(CXX) -o $@ $(SRC) $(CXXFLAGS) $(LDFLAGS)
@@ -24,10 +24,13 @@ test_setup:
 	g++ -std=c++11 -isystem ${GTEST_DIR}/include -I${GTEST_DIR} -pthread -c ${GTEST_DIR}/src/gtest-all.cc; \
 	ar -rv libgtest.a gtest-all.o;
 
-test: test_setup config_parser_test
+test: test_setup config_parser_test http_response_test server_config_parser_test
 
 config_parser_test: test_setup config_parser.cc config_parser_test.cc
-	g++ -std=c++11 -isystem ${GTEST_DIR}/include -pthread config_parser_test.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o config_parser_test
+	g++ -std=c++11 -isystem ${GTEST_DIR}/include -pthread config_parser_test.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ 
 
-http_response_test: test_setup
-	g++ -std=c++11 -isystem ${GTEST_DIR}/include -pthread http_response_test.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o http_response_test $(LDFLAGS)
+http_response_test: test_setup http_response.cc http_response_test.cc
+	g++ -std=c++11 -isystem ${GTEST_DIR}/include -pthread http_response_test.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@  $(LDFLAGS)
+
+server_config_parser_test: test_setup server_config_parser.cc server_config_parser_test.cc
+	g++ -std=c++11 -isystem ${GTEST_DIR}/include -pthread server_config_parser_test.cc server_config_parser.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -27,8 +27,8 @@ TEST(NginxConfigParserTest, SimpleConfigFile) {
 TEST(NginxConfigStatementTest, ToString) {
     NginxConfigStatement statement;
     
-    statement.tokens_.push_back("foo");
-    statement.tokens_.push_back("bar");
+    statement.tokens.push_back("foo");
+    statement.tokens.push_back("bar");
     
     EXPECT_EQ("foo bar;\n", statement.ToString(0));
 }
@@ -37,7 +37,7 @@ TEST(NginxConfigStatementTest, ToString) {
 TEST_F(NginxConfigParserStringTest, SimpleStatementConfig) {	
     ASSERT_TRUE(ParseString("foo bar;"));
     ASSERT_EQ(1, out_config.statements.size()) << "Config has only one statement.";
-    EXPECT_EQ("foo", out_config.statements[0]->tokens_[0]) << "foo is the first token.";	
+    EXPECT_EQ("foo", out_config.statements[0]->tokens[0]) << "foo is the first token.";	
 }
 
 

--- a/http_response.cc
+++ b/http_response.cc
@@ -169,8 +169,7 @@ boost::asio::const_buffer to_buffer(response::status_code status) {
 
 
 // Creates a default response for a given status code
-response response::default_response(response::status_code status)
-{
+response response::default_response(response::status_code status) {
     response r;
     r.status = status;
     r.content = default_responses::to_string(status);
@@ -184,8 +183,7 @@ response response::default_response(response::status_code status)
 
 
 // Creates a text/html response for the given text or html
-response response::text_or_html_response(std::string&& text_or_html)
-{
+response response::text_or_html_response(std::string&& text_or_html) {
     response r;
     r.status = response::ok;
     r.content = std::move(text_or_html);
@@ -197,8 +195,8 @@ response response::text_or_html_response(std::string&& text_or_html)
     return r;
 }
 
-response response::plain_text_response(std::string&& text_or_html)
-{
+// Creates a text/plain response for the given text or html
+response response::plain_text_response(std::string&& text_or_html) {
     response r;
     r.status = response::ok;
     r.content = std::move(text_or_html);
@@ -210,8 +208,8 @@ response response::plain_text_response(std::string&& text_or_html)
     return r;
 }
 
-response response::html_text_response(std::string&& text_or_html)
-{
+// Creates a text/html response for the given text or html
+response response::html_text_response(std::string&& text_or_html) {
     response r;
     r.status = response::ok;
     r.content = std::move(text_or_html);

--- a/http_response.cc
+++ b/http_response.cc
@@ -122,13 +122,6 @@ std::string to_string(response::status_code status)
 } // namespace default_responses
 
 
-namespace misc_string {
-
-// Strings used in forming an HTTP response
-const char field_separator[] = { ':', ' ' };
-const char crlf[] = { '\r', '\n' };
-
-} // namespace helper_strings
 
 
 namespace status_string {

--- a/http_response.cc
+++ b/http_response.cc
@@ -3,7 +3,7 @@
 
 namespace http {
 
-namespace default_responses {
+namespace default_responses{
 
 // Default message bodies for every status code in HTTP/1.0
 const char ok[] =
@@ -133,37 +133,6 @@ const char crlf[] = { '\r', '\n' };
 
 namespace status_string {
 
-// Status lines for every status code in HTTP/1.0
-const std::string ok =
-    "HTTP/1.0 200 OK\r\n";
-const std::string created =
-    "HTTP/1.0 201 Created\r\n";
-const std::string accepted =
-    "HTTP/1.0 202 Accepted\r\n";
-const std::string no_content =
-    "HTTP/1.0 204 No Content\r\n";
-const std::string moved_permanently =
-    "HTTP/1.0 301 Moved Permanently\r\n";
-const std::string moved_temporarily =
-    "HTTP/1.0 302 Moved Temporarily\r\n";
-const std::string not_modified =
-    "HTTP/1.0 304 Not Modified\r\n";
-const std::string bad_request =
-    "HTTP/1.0 400 Bad Request\r\n";
-const std::string unauthorized =
-    "HTTP/1.0 401 Unauthorized\r\n";
-const std::string forbidden =
-    "HTTP/1.0 403 Forbidden\r\n";
-const std::string not_found =
-    "HTTP/1.0 404 Not Found\r\n";
-const std::string internal_server_error =
-    "HTTP/1.0 500 Internal Server Error\r\n";
-const std::string not_implemented =
-    "HTTP/1.0 501 Not Implemented\r\n";
-const std::string bad_gateway =
-    "HTTP/1.0 502 Bad Gateway\r\n";
-const std::string service_unavailable =
-    "HTTP/1.0 503 Service Unavailable\r\n";
 
 // Gets status line for a given status code
 boost::asio::const_buffer to_buffer(response::status_code status) {
@@ -234,6 +203,35 @@ response response::text_or_html_response(std::string&& text_or_html)
     r.headers[1].value = "text/plain";
     return r;
 }
+
+response response::plain_text_response(std::string&& text_or_html)
+{
+    response r;
+    r.status = response::ok;
+    r.content = std::move(text_or_html);
+    r.headers.resize(2);
+    r.headers[0].name = "Content-Length";
+    r.headers[0].value = std::to_string(r.content.size());
+    r.headers[1].name = "Content-Type";
+    r.headers[1].value = "text/plain";
+    return r;
+}
+
+response response::html_text_response(std::string&& text_or_html)
+{
+    response r;
+    r.status = response::ok;
+    r.content = std::move(text_or_html);
+    r.headers.resize(2);
+    r.headers[0].name = "Content-Length";
+    r.headers[0].value = std::to_string(r.content.size());
+    r.headers[1].name = "Content-Type";
+    r.headers[1].value = "text/html";
+    return r;
+}
+
+
+
 
 
 // Converts the response into buffers so that it can be sent to the client

--- a/http_response.h
+++ b/http_response.h
@@ -51,6 +51,13 @@ struct response {
 };
 
 
+namespace misc_string {
+
+// Strings used in forming an HTTP response
+const char field_separator[] = { ':', ' ' };
+const char crlf[] = { '\r', '\n' };
+
+} // namespace helper_strings
 
 
 namespace default_responses {

--- a/http_response.h
+++ b/http_response.h
@@ -36,6 +36,12 @@ struct response {
     // Creates a text/html response for the given text or html
     static response text_or_html_response(std::string&& text_or_html);
 
+    static response plain_text_response(std::string&& text_or_html);
+
+    static response html_text_response(std::string&& text_or_html);
+
+    
+
     // Converts the response into buffers so that it can be sent to the client
     std::vector<boost::asio::const_buffer> to_buffers();
 
@@ -43,6 +49,60 @@ struct response {
     std::vector<header> headers; // Headers included in the response
     std::string         content; // Body of the response
 };
+
+
+
+
+namespace default_responses {
+
+// Gets default message body for a given status code
+std::string to_string(response::status_code status);
+
+} // namespace default_responses
+
+
+
+
+
+namespace status_string {
+
+// Status lines for every status code in HTTP/1.0
+const std::string ok =
+    "HTTP/1.0 200 OK\r\n";
+const std::string created =
+    "HTTP/1.0 201 Created\r\n";
+const std::string accepted =
+    "HTTP/1.0 202 Accepted\r\n";
+const std::string no_content =
+    "HTTP/1.0 204 No Content\r\n";
+const std::string moved_permanently =
+    "HTTP/1.0 301 Moved Permanently\r\n";
+const std::string moved_temporarily =
+    "HTTP/1.0 302 Moved Temporarily\r\n";
+const std::string not_modified =
+    "HTTP/1.0 304 Not Modified\r\n";
+const std::string bad_request =
+    "HTTP/1.0 400 Bad Request\r\n";
+const std::string unauthorized =
+    "HTTP/1.0 401 Unauthorized\r\n";
+const std::string forbidden =
+    "HTTP/1.0 403 Forbidden\r\n";
+const std::string not_found =
+    "HTTP/1.0 404 Not Found\r\n";
+const std::string internal_server_error =
+    "HTTP/1.0 500 Internal Server Error\r\n";
+const std::string not_implemented =
+    "HTTP/1.0 501 Not Implemented\r\n";
+const std::string bad_gateway =
+    "HTTP/1.0 502 Bad Gateway\r\n";
+const std::string service_unavailable =
+    "HTTP/1.0 503 Service Unavailable\r\n";
+
+
+} // namespace status_string
+
+
+
 
 } // namespace http
 

--- a/http_response_test.cc
+++ b/http_response_test.cc
@@ -1,0 +1,101 @@
+#include "gtest/gtest.h"
+#include "http_response.h"
+
+
+class HttpResponseDefaultResponseTest : public ::testing::Test {
+protected:
+    void VerifyContents(http::response::status_code status) {
+        r = http::response::default_response(status);
+
+	ASSERT_EQ(status, r.status);
+	ASSERT_EQ(http::default_responses::to_string(r.status), r.content);
+	ASSERT_EQ(2, r.headers.size());
+	EXPECT_EQ("Content-Length", r.headers[0].name);
+	EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+	EXPECT_EQ("Content-Type", r.headers[1].name);
+	EXPECT_EQ("text/html", r.headers[1].value);
+    }
+
+    http::response r;
+    
+ };
+
+
+
+
+
+TEST_F(HttpResponseDefaultResponseTest, OkStatus)
+{
+	VerifyContents(http::response::status_code::ok);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, CreatedStatus)
+{
+	VerifyContents(http::response::status_code::created);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, AcceptedStatus)
+{
+	VerifyContents(http::response::status_code::accepted);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, NoContentStatus)
+{
+	VerifyContents(http::response::status_code::no_content);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, MovedPermanentlyStatus)
+{
+	VerifyContents(http::response::status_code::moved_permanently);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, MovedTemporarilyStatus)
+{
+	VerifyContents(http::response::status_code::moved_temporarily);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, NotModifiedStatus)
+{
+	VerifyContents(http::response::status_code::not_modified);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, BadRequestStatus)
+{
+	VerifyContents(http::response::status_code::bad_request);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, UnauthorizedStatus)
+{
+	VerifyContents(http::response::status_code::unauthorized);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, ForbiddenStatus)
+{
+	VerifyContents(http::response::status_code::forbidden);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, NotFoundStatus)
+{
+	VerifyContents(http::response::status_code::not_found);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, InternalServerErrorStatus)
+{
+	VerifyContents(http::response::status_code::internal_server_error);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, NotImplementederrorStatus)
+{
+	VerifyContents(http::response::status_code::not_implemented);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, BadGatewayStatus)
+{
+	VerifyContents(http::response::status_code::bad_gateway);
+}
+
+TEST_F(HttpResponseDefaultResponseTest, ServiceUnavailableStatus)
+{
+	VerifyContents(http::response::status_code::service_unavailable);
+}
+

--- a/http_response_test.cc
+++ b/http_response_test.cc
@@ -24,78 +24,112 @@ protected:
 
 
 
-TEST_F(HttpResponseDefaultResponseTest, OkStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, OkStatus) {
 	VerifyContents(http::response::status_code::ok);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, CreatedStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, CreatedStatus) {
 	VerifyContents(http::response::status_code::created);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, AcceptedStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, AcceptedStatus) {
 	VerifyContents(http::response::status_code::accepted);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, NoContentStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, NoContentStatus) {
 	VerifyContents(http::response::status_code::no_content);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, MovedPermanentlyStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, MovedPermanentlyStatus) {
 	VerifyContents(http::response::status_code::moved_permanently);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, MovedTemporarilyStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, MovedTemporarilyStatus) {
 	VerifyContents(http::response::status_code::moved_temporarily);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, NotModifiedStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, NotModifiedStatus) {
 	VerifyContents(http::response::status_code::not_modified);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, BadRequestStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, BadRequestStatus) {
 	VerifyContents(http::response::status_code::bad_request);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, UnauthorizedStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, UnauthorizedStatus) {
 	VerifyContents(http::response::status_code::unauthorized);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, ForbiddenStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, ForbiddenStatus) {
 	VerifyContents(http::response::status_code::forbidden);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, NotFoundStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, NotFoundStatus) {
 	VerifyContents(http::response::status_code::not_found);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, InternalServerErrorStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, InternalServerErrorStatus) {
 	VerifyContents(http::response::status_code::internal_server_error);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, NotImplementederrorStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, NotImplementederrorStatus) {
 	VerifyContents(http::response::status_code::not_implemented);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, BadGatewayStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, BadGatewayStatus) {
 	VerifyContents(http::response::status_code::bad_gateway);
 }
 
-TEST_F(HttpResponseDefaultResponseTest, ServiceUnavailableStatus)
-{
+TEST_F(HttpResponseDefaultResponseTest, ServiceUnavailableStatus) {
 	VerifyContents(http::response::status_code::service_unavailable);
 }
 
+TEST(HttpResponseTest, html) {
+	http::response r = http::response::html_text_response(http::default_responses::to_string(http::response::status_code::ok));
+
+	ASSERT_EQ(http::response::status_code::ok, r.status);
+	ASSERT_EQ(http::default_responses::to_string(http::response::status_code::ok), r.content);
+	ASSERT_EQ(2, r.headers.size());
+	EXPECT_EQ("Content-Length", r.headers[0].name);
+	EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+	EXPECT_EQ("Content-Type", r.headers[1].name);
+	EXPECT_EQ("text/html", r.headers[1].value);
+    
+}
+
+TEST(HttpResponseTest, plain) {
+	http::response r = http::response::plain_text_response(http::default_responses::to_string(http::response::status_code::ok));
+
+	ASSERT_EQ(http::response::status_code::ok, r.status);
+	ASSERT_EQ(http::default_responses::to_string(http::response::status_code::ok), r.content);
+	ASSERT_EQ(2, r.headers.size());
+	EXPECT_EQ("Content-Length", r.headers[0].name);
+	EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+	EXPECT_EQ("Content-Type", r.headers[1].name);
+	EXPECT_EQ("text/plain", r.headers[1].value);
+    
+}
+
+
+TEST(ToBufferTest, generaltest) {
+
+	http::response r = http::response::plain_text_response(http::default_responses::to_string(http::response::status_code::ok));
+
+	ASSERT_EQ(http::response::status_code::ok, r.status);
+	ASSERT_EQ(http::default_responses::to_string(http::response::status_code::ok), r.content);
+	ASSERT_EQ(2, r.headers.size());
+	EXPECT_EQ("Content-Length", r.headers[0].name);
+	EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+	EXPECT_EQ("Content-Type", r.headers[1].name);
+	EXPECT_EQ("text/plain", r.headers[1].value);
+
+	std::vector<boost::asio::const_buffer> buffers =
+		r.to_buffers();
+
+	ASSERT_EQ(1 + r.headers.size() * 4 + 2, buffers.size());
+	
+    
+
+
+
+}

--- a/main.cc
+++ b/main.cc
@@ -4,7 +4,8 @@
 #include <utility>
 #include <boost/asio.hpp>
 #include "server.h"
-#include "config_parser.h"
+// #include "config_parser.h"
+#include "server_config_parser.h"
 
 using boost::asio::ip::tcp;
 
@@ -18,19 +19,26 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
-        // Parses the config file
-        NginxConfigParser config_parser;
-        NginxConfig config;
-        config_parser.Parse(argv[1], &config);
+        // // Parses the config file
+        // NginxConfigParser config_parser;
+        // NginxConfig config;
+        // config_parser.Parse(argv[1], &config);
         
-        // Extracts the port number from the config file
-        int port = 0;
-        for (size_t i = 0; i < config.statements.size(); i++) {
-            if (config.statements[i]->tokens[0] == "port") {
-                port = std::stoi(config.statements[i]->tokens[1]);
-            } 
-        }
-        if (port == 0) {
+        // // Extracts the port number from the config file
+        // int port = 0;
+        // for (size_t i = 0; i < config.statements.size(); i++) {
+        //     if (config.statements[i]->tokens[0] == "port") {
+        //         port = std::stoi(config.statements[i]->tokens[1]);
+        //     } 
+        // }
+        // if (port == 0) {
+        //     std::cerr << "Missing port <number> in config file" << std::endl;
+        //     return 1;
+        // }
+
+        int port = port_number(argv[1]);
+
+        if (port == -1) {
             std::cerr << "Missing port <number> in config file" << std::endl;
             return 1;
         }

--- a/main.cc
+++ b/main.cc
@@ -4,7 +4,6 @@
 #include <utility>
 #include <boost/asio.hpp>
 #include "server.h"
-// #include "config_parser.h"
 #include "server_config_parser.h"
 
 using boost::asio::ip::tcp;
@@ -19,23 +18,7 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
-        // // Parses the config file
-        // NginxConfigParser config_parser;
-        // NginxConfig config;
-        // config_parser.Parse(argv[1], &config);
-        
-        // // Extracts the port number from the config file
-        // int port = 0;
-        // for (size_t i = 0; i < config.statements.size(); i++) {
-        //     if (config.statements[i]->tokens[0] == "port") {
-        //         port = std::stoi(config.statements[i]->tokens[1]);
-        //     } 
-        // }
-        // if (port == 0) {
-        //     std::cerr << "Missing port <number> in config file" << std::endl;
-        //     return 1;
-        // }
-
+       
         int port = port_number(argv[1]);
 
         if (port == -1) {

--- a/server_config_parser.cc
+++ b/server_config_parser.cc
@@ -2,8 +2,8 @@
 
 // returns the port number from; returns -1 if no number is found
 int port_number(const char* config_file) {
-	int port = -1;
-	NginxConfigParser config_parser;
+    int port = -1;
+    NginxConfigParser config_parser;
     NginxConfig config;
     config_parser.Parse(config_file, &config);
     for (size_t i = 0; i < config.statements.size(); i++) {

--- a/server_config_parser.cc
+++ b/server_config_parser.cc
@@ -1,0 +1,15 @@
+#include "server_config_parser.h"
+
+// returns the port number from; returns -1 if no number is found
+int port_number(const char* config_file) {
+	int port = -1;
+	NginxConfigParser config_parser;
+    NginxConfig config;
+    config_parser.Parse(config_file, &config);
+    for (size_t i = 0; i < config.statements.size(); i++) {
+        if (config.statements[i]->tokens[0] == "port") {
+            port = std::stoi(config.statements[i]->tokens[1]);
+        } 
+    }
+    return port;
+}

--- a/server_config_parser.h
+++ b/server_config_parser.h
@@ -1,0 +1,13 @@
+#ifndef SERVER_CONFIG_PARSER_H
+#define SERVER_CONFIG_PARSER_H
+
+
+#include "config_parser.h"
+
+// returns the port number from; returns -1 if no number is found
+int port_number(const char* config_file);
+
+
+
+
+#endif // SERVER_CONFIG_PARSER_H

--- a/server_config_parser_test.cc
+++ b/server_config_parser_test.cc
@@ -1,0 +1,38 @@
+#include "gtest/gtest.h"
+#include "server_config_parser.h"
+
+
+
+class PortParseTest : public ::testing::Test {
+protected:
+    bool getPortNumber(std::string config_contents) {
+       	
+       	int fd;
+		char name[] = "/tmp/fileXXXXXX";
+		fd = mkstemp(name); // creates a temporary file using name, replacing the last 6 X's 
+
+		// write the config_contents into the temp file
+		write(fd, config_contents.c_str(), config_contents.size());
+    	
+    	port = port_number(name);
+    	remove(name) ;//delete the temporary file
+		return (port != -1);
+
+    }
+
+    int port;
+    
+ };
+
+
+
+
+TEST_F(PortParseTest, ValidPortConfig) {
+	ASSERT_TRUE(getPortNumber("port 80800;"));
+	EXPECT_EQ(80800, port);
+}
+
+TEST_F(PortParseTest, InvalidPortConfig) {
+	EXPECT_FALSE(getPortNumber("Port 80800;"));
+	
+}


### PR DESCRIPTION
Added unit tests

-  created unit tests for http_response
    -  did not add tests to observe contents of to_buffer due to boost buffer quirks of comparisons
    -  required some refactoring to expose some contents being used for the resoonse

-  created unit tests for parsing port number
    - refactored some of the code to be in its own file and be more testable

-  note: no unit tests for server.cc since it consists mostly of the boost library, which would result in tests just testing boost. The server itself should be tested within the integration test

Modified Makefile to compile these tests