### PR TITLE
Integration test fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 # Enable C++ support
 language: cpp
+
 # Ubuntu 14.04 Trusty support
 sudo: required
 dist: trusty
+
 # Compiler selection: g++
 compiler:
   - gcc
+
 # Download packages before running build 
 before_install:
   - sudo apt-get install libboost-all-dev
+
 # Build steps
-script: make
+script: make test
+

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
-# GoogleTest directory and output files
-GTEST_DIR=googletest/googletest
-GTEST_FILES=libgtest.a gtest-all.o
-
 # Name of the executable
 TARGET=webserver
 
 # Test executables
 TESTEXEC=config_parser_test server_config_parser_test http_response_test
+GCOVEXEC=config_parser_gcov server_config_parser_gcov http_response_gcov
+
+# GoogleTest directory and output files
+GTEST_DIR=googletest/googletest
+GTEST_FILES=libgtest.a gtest-all.o
 
 # Gcov flags and files
-GCOVFLAGS+=-fprofile-arcs -ftest-coverage
+GCOVFLAGS=-fprofile-arcs -ftest-coverage
 GCOVFILES=*.gcno *.gcda *.gcov
 
 # Compiler flags
@@ -18,37 +19,50 @@ CXXFLAGS+=-std=c++11 -Wall -Werror
 # Linker flags
 LDFLAGS+=-lboost_system
 
+# Test flags
+TESTFLAGS=-std=c++11 -isystem ${GTEST_DIR}/include -pthread
+
 # Source files
 SRC=main.cc server.cc config_parser.cc http_response.cc server_config_parser.cc
 
-$(TARGET): clean
+.PHONY: clean clean_target gcov test test_gcov test_setup
+
+$(TARGET): clean_target
 	$(CXX) -o $@ $(SRC) $(CXXFLAGS) $(LDFLAGS)
 
-.PHONY: clean test 
+clean_target:
+	$(RM) $(TARGET)
 
-clean:
-	$(RM) $(TARGET) $(OBJS) $(GCOVFILES) $(TESTEXEC) $(GTEST_FILES)
+clean: clean_target
+	$(RM) $(GCOVFILES) $(TESTEXEC) $(GTEST_FILES)
+
+test_gcov: $(TARGET) $(GCOVEXEC)
 
 test_setup: 
-	g++ -std=c++11 -isystem ${GTEST_DIR}/include -I${GTEST_DIR} -pthread -c ${GTEST_DIR}/src/gtest-all.cc; \
-	ar -rv libgtest.a gtest-all.o;
+	g++ $(TESTFLAGS) -I${GTEST_DIR} -c ${GTEST_DIR}/src/gtest-all.cc
+	ar -rv libgtest.a gtest-all.o
 
-test: test_setup config_parser_test http_response_test server_config_parser_test
+test: $(TARGET) $(TESTEXEC)
+	python webserver_test.py
 
 config_parser_test: test_setup config_parser.cc config_parser_test.cc
-	g++ -std=c++11 $(GCOVFLAGS) -isystem ${GTEST_DIR}/include -pthread config_parser_test.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ 
+	g++ $(GCOVFLAGS) $(TESTFLAGS) config_parser_test.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	./$@
+
+config_parser_gcov:
+	gcov -r config_parser_test.cc && gcov -r config_parser_test.h && gcov -r config_parser.cc && gcov -r config_parser.h
 
 http_response_test: test_setup http_response.cc http_response_test.cc
-	g++ -std=c++11 $(GCOVFLAGS) -isystem ${GTEST_DIR}/include -pthread http_response_test.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@  $(LDFLAGS)
+	g++ $(GCOVFLAGS) $(TESTFLAGS) http_response_test.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	./$@
+
+http_response_gcov:
+	gcov -r http_response_test.cc && gcov -r http_response_test.h && gcov -r http_response.cc && gcov -r http_response.h
 
 server_config_parser_test: test_setup server_config_parser.cc server_config_parser_test.cc
-	g++ -std=c++11 $(GCOVFLAGS) -isystem ${GTEST_DIR}/include -pthread server_config_parser_test.cc server_config_parser.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	g++ $(GCOVFLAGS) $(TESTFLAGS) server_config_parser_test.cc server_config_parser.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	./$@
 
-gcov_config_parser_test:
-	./config_parser_test && gcov -r config_parser_test.cc && gcov -r config_parser_test.h && gcov -r config_parser.cc && gcov -r config_parser.h
+server_config_parser_gcov:
+	gcov -r server_config_parser_test.cc && gcov -r server_config_parser_test.h && gcov server_config_parser.cc && gcov server_config_parser.h
 
-gcov_http_response_test:
-	./http_response_test && gcov -r http_response_test.cc && gcov -r http_response_test.h && gcov -r http_response.cc && gcov -r http_response.h
-
-gcov_server_config_parser_test:
-	./server_config_parser_test && gcov -r server_config_parser_test.cc && gcov -r server_config_parser_test.h && gcov server_config_parser.cc && gcov server_config_parser.h


### PR DESCRIPTION
I did the following
* Fixed the integration test to work with Trusty and my laptop's distribution of Ubuntu
* Updated travis so that is runs all the tests
* Updated the makefile so "make test" runs all the tests
* Updated the makefile so "make gcov" runs all the gcov stuff
* Renamed all the gcov targets, refactored the makefile a bit