### PR TITLE
Server config parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ http_response_gcov: http_response_test
 	gcov -r http_response.cc > http_response_gcov.txt
 
 server_config_parser_test: test_setup server_config_parser.cc server_config_parser_test.cc
-	g++ $(GCOVFLAGS) $(TESTFLAGS) server_config_parser_test.cc server_config_parser.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	g++ $(GCOVFLAGS) $(TESTFLAGS) server_config_parser_test.cc server_config_parser.cc config_parser.cc http_handler_file.cc http_handler_echo.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
 	./$@
 
 server_config_parser_gcov: server_config_parser_test

--- a/http_handler.h
+++ b/http_handler.h
@@ -14,8 +14,10 @@ struct request;
 class handler {
 public:
 
+    // Construct handler with the base url such as "/echo" or "/static1"
     handler(const std::string& url) : base_url(url) { };
-    
+
+    // Virtual destructor necessary for deleting derived classes via base class
     virtual ~handler() {};    
 
     // Returns a response to the given request

--- a/main.cc
+++ b/main.cc
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) {
         // Parse the echo and static file request handlers from the config file
         std::vector<std::unique_ptr<http::handler> > handlers;
         server_parser.ParseRequestHandlers(handlers);
-        printf("%lu number of handlers\n", handlers.size());
+        printf("%u handlers parsed\n", handlers.size());
 
         // Start the server
         boost::asio::io_service io_service;

--- a/main.cc
+++ b/main.cc
@@ -17,28 +17,21 @@ int main(int argc, char* argv[]) {
             std::cerr << "Usage: webserver <config_file>" << std::endl;
             return 1;
         }
+	
+        // Parse the config file into statements and tokens
+        NginxServerConfigParser server_parser(argv[1]);
 
-        // Get the port number from the config file
-        int port = port_number(argv[1]);
+        // Get the server settings from the config file (i.e. port)
+        server_config server_settings;
+        int port = server_parser.parseServerSettings(&server_settings);
         if (port == -1) {
             std::cerr << "Missing port <number> in config file" << std::endl;
             return 1;
         }
 
-        
-        // TODO: replace this with info from the config parser
-             
+        // Parse the echo and static file request handlers from the config file
         std::vector<http::handler *> handlers;
-
-        http::handler_echo handler0("/echo");
-        http::handler_file handler1(".", "/static1");
-
-        handlers.push_back(&handler0);
-        handlers.push_back(&handler1);
-      
-
-       
-        
+        server_parser.parseRequestHandlers(&handlers);
 
         // Start the server
         boost::asio::io_service io_service;

--- a/main.cc
+++ b/main.cc
@@ -23,7 +23,7 @@ int main(int argc, char* argv[]) {
 
         // Get the server settings from the config file (i.e. port)
         server_config server_settings;
-        int port = server_parser.parseServerSettings(&server_settings);
+        int port = server_parser.ParseServerSettings(server_settings);
         if (port == -1) {
             std::cerr << "Missing port <number> in config file" << std::endl;
             return 1;
@@ -31,12 +31,12 @@ int main(int argc, char* argv[]) {
 
         // Parse the echo and static file request handlers from the config file
         std::vector<std::unique_ptr<http::handler> > handlers;
-        server_parser.parseRequestHandlers(&handlers);
-        printf("%d number of handlers\n", handlers.size());        
+        server_parser.ParseRequestHandlers(handlers);
+        printf("%lu number of handlers\n", handlers.size());
 
         // Start the server
         boost::asio::io_service io_service;
-        server s(io_service, port, handlers);
+        server s(io_service, port, std::move(handlers));
         printf("Running server on port %d...\n", port);
         io_service.run();
     } catch (std::exception& e) {

--- a/port_config
+++ b/port_config
@@ -1,2 +1,5 @@
 port 1234;
 
+echo /echo_url;
+
+static_serve /static_serve_url /root_directory;

--- a/port_config
+++ b/port_config
@@ -1,5 +1,10 @@
 port 1234;
 
-echo /echo_url;
+echo /echo;
 
-static_serve /static_serve_url /root_directory;
+echo /echo2;
+
+static_serve /static_serve ./;
+
+static_serve /static_serve_team ./;
+

--- a/server.cc
+++ b/server.cc
@@ -13,9 +13,10 @@
 using boost::asio::ip::tcp;
 
 
-// Constructor
-session::session(tcp::socket sock, const std::vector<std::unique_ptr<http::handler> > &handlers) :
-    socket(std::move(sock)), handlers(handlers) {
+// Constructor taking a list of HTTP request handlers
+session::session(tcp::socket sock,
+const std::vector<std::unique_ptr<http::handler> >& hndlers) :
+handlers(hndlers), socket(std::move(sock)) {
 
 }
 
@@ -89,12 +90,12 @@ void session::do_write(const http::response& res) {
 }
 
 
-// Constructor
-server::server(boost::asio::io_service& io_service, short port, std::vector<std::unique_ptr<http::handler> > handlers) :
-    acceptor(io_service, tcp::endpoint(tcp::v4(), port)), 
-    socket(io_service) {
+// Constructor taking a list of HTTP request handlers
+server::server(boost::asio::io_service& io_service, short port,
+const std::vector<std::unique_ptr<http::handler> >& hndlers) :
+handlers(hndlers), acceptor(io_service, tcp::endpoint(tcp::v4(), port)),
+socket(io_service) {
     // Start accepting clients as soon as the server instance is created
-    this->handlers = handlers;
     do_accept();
 }
 
@@ -108,7 +109,7 @@ void server::do_accept()
             // Check if an error has occurred during the connection
             if (!ec) {
                 // No error : creates a session between the client and server
-                std::make_shared<session>(std::move(socket), this->handlers)->start();
+                std::make_shared<session>(std::move(socket), handlers)->start();
             }
 
             // Repeatedly do this

--- a/server.cc
+++ b/server.cc
@@ -1,7 +1,6 @@
 // This file is based on both the Boost HTTP server and Echo example at
 //  http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/examples/cpp11_examples.html
 
-
 #include <cstdlib>
 #include <iostream>
 #include <memory>

--- a/server.h
+++ b/server.h
@@ -19,8 +19,9 @@ using boost::asio::ip::tcp;
 class session : public std::enable_shared_from_this<session> {
 public:
 
-    // Constructor
-    session(tcp::socket sock, const std::vector<std::unique_ptr<http::handler> >&handlers);
+    // Constructor taking a list of HTTP request handlers
+    session(tcp::socket sock,
+        const std::vector<std::unique_ptr<http::handler> >& hndlers);
 
     // Starts the session between client and server
     void start();
@@ -36,11 +37,13 @@ private:
     // Callback for when a client should be written to
     void do_write(const http::response& res);
 
+    // Reference to the vector of request handlers
+    const std::vector<std::unique_ptr<http::handler> >& handlers;
+
     std::array<char, max_length> buf; // Buffer used when reading client data
     http::request_parser parser;      // Parser for incoming client requests
     http::request        request;     // Structure for storing client requests
     tcp::socket          socket;      // Used to represent a client
-    const std::vector<std::unique_ptr<http::handler> >& handlers; // Vector of request handlers
 };
 
 
@@ -48,17 +51,20 @@ private:
 class server  {
 public:
 
-    // Constructor
-    server(boost::asio::io_service& io_service, short port, std::vector<std::unique_ptr<http::handler> > handlers);
+    // Constructor taking a list of HTTP request handlers
+    server(boost::asio::io_service& io_service, short port,
+        const std::vector<std::unique_ptr<http::handler> >& hndlers);
 
 private:
 
     // Callback for when a client attempts to connect
     void do_accept();
 
+    // Vector of request handlers - used across multiple sessions/threads
+    const std::vector<std::unique_ptr<http::handler> >& handlers;
+
     tcp::acceptor acceptor; // Used in boost.asio to take in new clients
     tcp::socket   socket;   // Used in boost.asio to represent clients
-    std::vector<std::unique_ptr<http::handler> > handlers; // Vector of request handlers, going to be used across multiple threads
 };
 
 #endif // SERVER_H

--- a/server_config_parser.cc
+++ b/server_config_parser.cc
@@ -12,7 +12,7 @@ NginxServerConfigParser::NginxServerConfigParser(const char* config_file) {
 // handlers in a vector out-param. Returns number of request handlers found
 int NginxServerConfigParser::parseRequestHandlers(
     std::vector<http::handler *>* handlers_out) {
-    /*
+    
     // Check config file for echo/static file requests to add
     for (size_t i = 0; i < config.statements.size(); i++) {
         // Add echo handler with its base URL
@@ -28,15 +28,13 @@ int NginxServerConfigParser::parseRequestHandlers(
     }
     
     return handlers_out->size();
-    */
-    return 1;
 }
 
 // Parses all server settings and stores the parsed server setup in 
 // server_config out-parm. Returns port number (-1 if no number is found)
-int NginxServerConfigParser::parseServerSettings(
-    server_config* server_setings_out) {
-    /*
+int NginxServerConfigParser::parseServerSettings(server_config* 
+    server_settings_out) {
+    
     server_settings_out->port = -1;
    
     for (size_t i = 0; i < config.statements.size(); i++) {
@@ -47,8 +45,6 @@ int NginxServerConfigParser::parseServerSettings(
     }
  
     return server_settings_out->port;
-    */
-    return 1;
 }
 
 // Returns the port number from config_file or -1 if no number is found

--- a/server_config_parser.cc
+++ b/server_config_parser.cc
@@ -2,48 +2,49 @@
 #include "http_handler_echo.h"
 #include "http_handler_file.h"
 
+
 // Constructor: pass in a config file to be parsed for its contents
 NginxServerConfigParser::NginxServerConfigParser(const char* config_file) {
-    // Parses the config file into statements and tokens for us to extract data
+    // Parse the config file into statements and tokens for us to extract data
     config_parser.Parse(config_file, &config);
 }
 
+
 // Parses all server echo/static file request handlers and stores the parsed
 // handlers in a vector out-param. Returns number of request handlers found
-int NginxServerConfigParser::parseRequestHandlers(
-    std::vector<std::unique_ptr<http::handler> >* handlers_out) {
-    
+int NginxServerConfigParser::ParseRequestHandlers(
+std::vector<std::unique_ptr<http::handler> >& handlers_out) {
     // Check config file for echo/static file requests to add
     for (size_t i = 0; i < config.statements.size(); i++) {
         // Add echo handler with its base URL
         if (config.statements[i]->tokens[0] == "echo") {
-            handlers_out->push_back(std::unique_ptr<http::handler>(
-                new http::handler_echo(config.statements[i]->tokens[1])));
+            handlers_out.push_back(std::move(std::unique_ptr<http::handler>(
+                new http::handler_echo(config.statements[i]->tokens[1]))));
         // Add static file with its root directory and base URL
         } else if (config.statements[i]->tokens[0] == "static_serve") {
-            handlers_out->push_back(std::unique_ptr<http::handler>(
+            handlers_out.push_back(std::move(std::unique_ptr<http::handler>(
                 new http::handler_file(config.statements[i]->tokens[2],
-                                       config.statements[i]->tokens[1])));
+                                       config.statements[i]->tokens[1]))));
         }
     }
-    
-    return handlers_out->size();
+
+    return handlers_out.size();
 }
+
 
 // Parses all server settings and stores the parsed server setup in 
 // server_config out-parm. Returns port number (-1 if no number is found)
-int NginxServerConfigParser::parseServerSettings(server_config* 
-    server_settings_out) {
-    
-    server_settings_out->port = -1;
-   
+int NginxServerConfigParser::ParseServerSettings(
+server_config& server_settings_out) {
+    server_settings_out.port = -1;
+
     for (size_t i = 0; i < config.statements.size(); i++) {
         if (config.statements[i]->tokens[0] == "port") {
-            server_settings_out->port = 
+            server_settings_out.port =
                                   std::stoi(config.statements[i]->tokens[1]);
         }
     }
- 
-    return server_settings_out->port;
+
+    return server_settings_out.port;
 }
 

--- a/server_config_parser.cc
+++ b/server_config_parser.cc
@@ -1,5 +1,55 @@
 #include "server_config_parser.h"
+#include "http_handler_echo.h"
+#include "http_handler_file.h"
 
+// Constructor: pass in a config file to be parsed for its contents
+NginxServerConfigParser::NginxServerConfigParser(const char* config_file) {
+    // Parses the config file into statements and tokens for us to extract data
+    config_parser.Parse(config_file, &config);
+}
+
+// Parses all server echo/static file request handlers and stores the parsed
+// handlers in a vector out-param. Returns number of request handlers found
+int NginxServerConfigParser::parseRequestHandlers(
+    std::vector<http::handler *>* handlers_out) {
+    /*
+    // Check config file for echo/static file requests to add
+    for (size_t i = 0; i < config.statements.size(); i++) {
+        // Add echo handler with its base URL
+        if (config.statements[i]->tokens[0] == "echo") {
+            http::handler_echo handler(config.statements[i]->tokens[1]);
+            handlers_out->push_back(&handler);
+        // Add static file with its root directory and base URL
+        } else if (config.statements[i]->tokens[0] == "static_serve") {
+            http::handler_file handler(config.statements[i]->tokens[2],
+                                       config.statements[i]->tokens[1]);
+            handlers_out->push_back(&handler);
+        }
+    }
+    
+    return handlers_out->size();
+    */
+    return 1;
+}
+
+// Parses all server settings and stores the parsed server setup in 
+// server_config out-parm. Returns port number (-1 if no number is found)
+int NginxServerConfigParser::parseServerSettings(
+    server_config* server_setings_out) {
+    /*
+    server_settings_out->port = -1;
+   
+    for (size_t i = 0; i < config.statements.size(); i++) {
+        if (config.statements[i]->tokens[0] == "port") {
+            server_settings_out->port = 
+                                  std::stoi(config.statements[i]->tokens[1]);
+        }
+    }
+ 
+    return server_settings_out->port;
+    */
+    return 1;
+}
 
 // Returns the port number from config_file or -1 if no number is found
 //   TODO: Put this in a class as a static method

--- a/server_config_parser.h
+++ b/server_config_parser.h
@@ -2,7 +2,31 @@
 #define SERVER_CONFIG_PARSER_H
 
 #include "config_parser.h"
+#include "http_handler_echo.h"
+#include "http_handler_file.h"
 
+struct server_config {
+    int port;
+    // TODO: Add in more server specific configurations here
+};
+
+// The driver that parses a config file for port and request handlers
+class NginxServerConfigParser {
+public:
+    // Constructor: pass in a config file to be parsed for its contents
+    NginxServerConfigParser(const char* config_file);
+    // Parses all server echo/static file request handlers and stores
+    // the parsed handlers in vector out-param. Returns number of request 
+    // handlers found
+    int parseRequestHandlers(std::vector<http::handler *>* handlers_out);
+    // Parses all server settings and stores the parsed server setup
+    // in server_config out-param. Returns port number (-1 if no number is
+    // found)
+    int parseServerSettings(server_config* server_settings_out);
+private:
+    NginxConfigParser config_parser; // Config parser to parse a file
+    NginxConfig config;              // File's config contents after parsing
+};
 
 // Returns the port number from config_file or -1 if no number is found
 //   TODO: Put this in a class as a static method

--- a/server_config_parser.h
+++ b/server_config_parser.h
@@ -13,20 +13,25 @@ struct server_config {
 // The driver that parses a config file for port and request handlers
 class NginxServerConfigParser {
 public:
+
     // Constructor: pass in a config file to be parsed for its contents
     NginxServerConfigParser(const char* config_file);
+
     // Parses all server echo/static file request handlers and stores
     // the parsed handlers in vector out-param. Returns number of request 
     // handlers found
-    int parseRequestHandlers(std::vector<std::unique_ptr<http::handler> >* 
-                             handlers_out);
+    int ParseRequestHandlers(
+        std::vector<std::unique_ptr<http::handler> >& handlers_out);
+
     // Parses all server settings and stores the parsed server setup
     // in server_config out-param. Returns port number (-1 if no number is
     // found)
-    int parseServerSettings(server_config* server_settings_out);
+    int ParseServerSettings(server_config& server_settings_out);
+
 private:
+
+    NginxConfig       config;        // File's config contents after parsing
     NginxConfigParser config_parser; // Config parser to parse a file
-    NginxConfig config;              // File's config contents after parsing
 };
 
 #endif // SERVER_CONFIG_PARSER_H

--- a/server_config_parser_test.cc
+++ b/server_config_parser_test.cc
@@ -15,7 +15,11 @@ protected:
         // Write the config_contents into the temp file
         write(fd, config_contents.c_str(), config_contents.size());
 
-        port = port_number(name);
+        // Initilize server parser
+        NginxServerConfigParser server_parser(name);
+      
+        // Get the port number
+        port = server_parser.ParseServerSettings(server_settings);
 
         // Delete the temporary file
         remove(name);
@@ -24,6 +28,8 @@ protected:
     }
 
     int port;
+    server_config server_settings;
+
 };
 
 

--- a/server_config_parser_test.cc
+++ b/server_config_parser_test.cc
@@ -4,7 +4,8 @@
 
 class PortParseTest : public ::testing::Test {
 protected:
-
+    // Test to check if server parser can read in port correctly
+    // Returns true if the port is not -1
     bool getPortNumber(std::string config_contents) {
         int fd;
         char name[] = "/tmp/fileXXXXXX";
@@ -15,7 +16,7 @@ protected:
         // Write the config_contents into the temp file
         write(fd, config_contents.c_str(), config_contents.size());
 
-        // Initilize server parser
+        // Initialize server parser
         NginxServerConfigParser server_parser(name);
       
         // Get the port number
@@ -43,3 +44,41 @@ TEST_F(PortParseTest, InvalidPortConfig) {
     EXPECT_FALSE(getPortNumber("Port 80800;"));
 }
 
+class HandlerParseTest : public ::testing::Test {
+protected:
+    // Test to check the number of handlers parsed from config file
+    // Returns true iff at least one handler is parsed
+    bool getNumberOfHandlersParsed(std::string config_contents) {
+        int fd;
+        char name[] = "/tmp/fileXXXXXX";
+
+        // Creates a temporary file using name, replacing the last 6 X's
+        fd = mkstemp(name);
+
+        // Write the config_contents into the temp file
+        write(fd, config_contents.c_str(), config_contents.size());
+        
+        // Initialize server parser
+        NginxServerConfigParser server_parser(name);
+        
+        // Parse the echo and static file request handlers from the config file
+        server_parser.ParseRequestHandlers(handlers);
+        
+        num_parsed_handlers = handlers.size();
+        return num_parsed_handlers;
+    }
+
+    std::vector<std::unique_ptr<http::handler> > handlers;
+    int num_parsed_handlers;
+    
+};
+
+TEST_F(HandlerParseTest, NoHandlersConfig) {
+    ASSERT_FALSE(getNumberOfHandlersParsed("no /handlers;"));
+    EXPECT_EQ(num_parsed_handlers, 0);
+}
+
+TEST_F(HandlerParseTest, SomeHandlersConfig) {
+    ASSERT_TRUE(getNumberOfHandlersParsed("echo /echo;\nstatic_serve /static_serve ./;"));
+    EXPECT_EQ(num_parsed_handlers, 2);
+}

--- a/webserver_test.py
+++ b/webserver_test.py
@@ -5,7 +5,7 @@ import sys
 
 # The expected output from curl as a regular expression
 curl_output_expected = [
-    "GET /echo HTTP/1\\.0\r\n",
+    "GET /echo_url HTTP/1\\.0\r\n",
     "Host: localhost:\\d+\r\n",
     "User-Agent: curl/\\d+\\.\\d+\\.\\d+\r\n",
     "Accept: \\*/\\*\r\n"
@@ -18,7 +18,7 @@ ec = 0
 webserver = Popen(["./webserver", "port_config"], stdout=PIPE)
 
 # Query the web server using curl
-curl = Popen(["curl", "-0", "-s", "localhost:1234/echo"], stdout=PIPE)
+curl = Popen(["curl", "-0", "-s", "localhost:1234/echo_url"], stdout=PIPE)
 curl_output = curl.communicate()[0].decode()
 sys.stdout.write("\nActual output from server\n")
 sys.stdout.write("==========\n")

--- a/webserver_test.py
+++ b/webserver_test.py
@@ -5,7 +5,7 @@ import sys
 
 # The expected output from curl as a regular expression
 curl_output_expected = [
-    "GET /echo_url HTTP/1\\.0\r\n",
+    "GET /echo HTTP/1\\.0\r\n",
     "Host: localhost:\\d+\r\n",
     "User-Agent: curl/\\d+\\.\\d+\\.\\d+\r\n",
     "Accept: \\*/\\*\r\n"
@@ -18,7 +18,7 @@ ec = 0
 webserver = Popen(["./webserver", "port_config"], stdout=PIPE)
 
 # Query the web server using curl
-curl = Popen(["curl", "-0", "-s", "localhost:1234/echo_url"], stdout=PIPE)
+curl = Popen(["curl", "-0", "-s", "localhost:1234/echo"], stdout=PIPE)
 curl_output = curl.communicate()[0].decode()
 sys.stdout.write("\nActual output from server\n")
 sys.stdout.write("==========\n")


### PR DESCRIPTION
Added server config parser that parses a config file for server settings (i.e. port) in a server_config struct and request handlers (static file serve and echo) in a std::vector<std::unique_ptr<http::handler> > (Thank you Brandon for fixing the compiler erros) with some unit tests for port number and parsing handlers