### PR TITLE
New api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,11 @@ http_request_parser_gcov: http_request_parser_test
 
 # Based off of https://github.com/jfarrell468/registerer
 registerer_example: clean_registerer_example
-	g++ -g -o $@ -std=c++11 echo_handler.cc static_file_handler.cc registerer_main.cc request_handler.cc
+	g++ -g -o $@ -std=c++11 echo_handler.cc static_file_handler.cc registerer_main.cc request_handler.cc response.cc $(CXXFLAGS) $(LDFLAGS)
 
 clean_registerer_example:
 	$(RM) registerer_example
+
+response_test: test_setup response.cc response_test.cc
+	g++ $(GCOVFLAGS) $(TESTFLAGS) response_test.cc response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	./$@

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 TARGET=webserver
 
 # Test executables
-TESTEXEC=config_parser_test server_config_parser_test http_response_test \
+TESTEXEC=config_parser_test server_config_parser_test response_test \
 http_handler_file_test http_handler_echo_test http_request_parser_test
-GCOVEXEC=config_parser_gcov server_config_parser_gcov http_response_gcov \
+GCOVEXEC=config_parser_gcov server_config_parser_gcov response_gcov \
 http_handler_file_gcov http_handler_echo_gcov http_request_parser_gcov
 
 # GoogleTest directory and output files
@@ -25,7 +25,7 @@ LDFLAGS+=-lboost_system
 TESTFLAGS=-std=c++11 -isystem ${GTEST_DIR}/include -pthread
 
 # Source files
-SRC=main.cc server.cc config_parser.cc http_response.cc \
+SRC=main.cc server.cc config_parser.cc response.cc \
 server_config_parser.cc http_request_parser.cc http_handler_echo.cc \
 http_handler_file.cc
 
@@ -58,29 +58,36 @@ config_parser_test: test_setup config_parser.cc config_parser_test.cc
 config_parser_gcov: config_parser_test
 	gcov -r config_parser.cc > config_parser_gcov.txt
 
-http_response_test: test_setup http_response.cc http_response_test.cc
-	g++ $(GCOVFLAGS) $(TESTFLAGS) http_response_test.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+#http_response_test: test_setup http_response.cc http_response_test.cc
+#	g++ $(GCOVFLAGS) $(TESTFLAGS) http_response_test.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+#	./$@
+
+#http_response_gcov: http_response_test
+#	gcov -r http_response.cc > http_response_gcov.txt
+
+response_test: test_setup response.cc response_test.cc
+	g++ $(GCOVFLAGS) $(TESTFLAGS) response_test.cc response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
 	./$@
 
-http_response_gcov: http_response_test
-	gcov -r http_response.cc > http_response_gcov.txt
+response_gcov: response_test
+	gcov -r response.cc > response_gcov.txt	
 
 server_config_parser_test: test_setup server_config_parser.cc server_config_parser_test.cc
-	g++ $(GCOVFLAGS) $(TESTFLAGS) server_config_parser_test.cc server_config_parser.cc config_parser.cc http_handler_file.cc http_handler_echo.cc http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	g++ $(GCOVFLAGS) $(TESTFLAGS) server_config_parser_test.cc server_config_parser.cc config_parser.cc http_handler_file.cc http_handler_echo.cc response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
 	./$@
 
 server_config_parser_gcov: server_config_parser_test
 	gcov -r server_config_parser.cc > server_config_parser_gcov.txt
 
 http_handler_file_test: test_setup http_handler_file.cc
-	g++ $(GCOVFLAGS) $(TESTFLAGS) http_handler_file_test.cc http_handler_file.cc http_request.h http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	g++ $(GCOVFLAGS) $(TESTFLAGS) http_handler_file_test.cc http_handler_file.cc http_request.h response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
 	./$@
 
 http_handler_file_gcov: http_handler_file_test
 	gcov -r http_handler_file.cc > http_handler_file_gcov.txt
 
 http_handler_echo_test: test_setup http_handler_echo.cc
-	g++ $(GCOVFLAGS) $(TESTFLAGS) http_handler_echo_test.cc http_handler_echo.cc http_request.h http_response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
+	g++ $(GCOVFLAGS) $(TESTFLAGS) http_handler_echo_test.cc http_handler_echo.cc http_request.h response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
 	./$@
 
 http_handler_echo_gcov: http_handler_echo_test
@@ -100,6 +107,4 @@ registerer_example: clean_registerer_example
 clean_registerer_example:
 	$(RM) registerer_example
 
-response_test: test_setup response.cc response_test.cc
-	g++ $(GCOVFLAGS) $(TESTFLAGS) response_test.cc response.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)
-	./$@
+

--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,9 @@ http_request_parser_test: test_setup http_request_parser_test.cc
 http_request_parser_gcov: http_request_parser_test
 	gcov -r http_request_parser.cc > http_request_parser_gcov.txt
 
+# Based off of https://github.com/jfarrell468/registerer
+registerer_example: clean_registerer_example
+	g++ -g -o $@ -std=c++11 echo_handler.cc static_file_handler.cc registerer_main.cc request_handler.cc
+
+clean_registerer_example:
+	$(RM) registerer_example

--- a/config_parser.h
+++ b/config_parser.h
@@ -1,3 +1,8 @@
+
+#ifndef CONFIG_PARSER_H
+#define CONFIG_PARSER_H
+
+
 #include <iostream>
 #include <memory>
 #include <string>
@@ -63,3 +68,4 @@ private:
     TokenType ParseToken(std::istream* input, std::string* value);
 };
 
+#endif // CONFIG_PARSER_H

--- a/echo_handler.cc
+++ b/echo_handler.cc
@@ -1,0 +1,10 @@
+#include "echo_handler.h"
+
+
+RequestHandler::Status EchoHandler::Init(const std::string& uri_prefix, const NginxConfig& config) {
+  std::cout << "EchoHandler::Init called" << std::endl;
+}
+
+RequestHandler::Status EchoHandler::HandleRequest(const Request& request, Response* response) {
+  std::cout << "EchoHandler::HandleRequest called" << std::endl;
+}

--- a/echo_handler.cc
+++ b/echo_handler.cc
@@ -3,8 +3,10 @@
 
 RequestHandler::Status EchoHandler::Init(const std::string& uri_prefix, const NginxConfig& config) {
   std::cout << "EchoHandler::Init called" << std::endl;
+  return RequestHandler::OK;
 }
 
 RequestHandler::Status EchoHandler::HandleRequest(const Request& request, Response* response) {
   std::cout << "EchoHandler::HandleRequest called" << std::endl;
+  return RequestHandler::OK;
 }

--- a/echo_handler.cc
+++ b/echo_handler.cc
@@ -1,12 +1,11 @@
 #include "echo_handler.h"
 
-
 RequestHandler::Status EchoHandler::Init(const std::string& uri_prefix, const NginxConfig& config) {
-  std::cout << "EchoHandler::Init called" << std::endl;
-  return RequestHandler::OK;
+    std::cout << "EchoHandler::Init called" << std::endl;
+    return RequestHandler::OK;
 }
 
 RequestHandler::Status EchoHandler::HandleRequest(const Request& request, Response* response) {
-  std::cout << "EchoHandler::HandleRequest called" << std::endl;
-  return RequestHandler::OK;
+    std::cout << "EchoHandler::HandleRequest called" << std::endl;
+    return RequestHandler::OK;
 }

--- a/echo_handler.h
+++ b/echo_handler.h
@@ -1,0 +1,16 @@
+#ifndef ECHO_HANDLER_H
+#define ECHO_HANDLER_H
+
+#include "request_handler.h"
+#include <iostream>
+
+class EchoHandler : public RequestHandler {
+ public:
+  Status Init(const std::string& uri_prefix, const NginxConfig& config);
+
+  Status HandleRequest(const Request& request, Response* response);
+};
+
+REGISTER_REQUEST_HANDLER(EchoHandler);
+
+#endif  // ECHO_HANDLER_H

--- a/echo_handler.h
+++ b/echo_handler.h
@@ -5,10 +5,10 @@
 #include <iostream>
 
 class EchoHandler : public RequestHandler {
- public:
-  Status Init(const std::string& uri_prefix, const NginxConfig& config);
+public:
+    Status Init(const std::string& uri_prefix, const NginxConfig& config);
 
-  Status HandleRequest(const Request& request, Response* response);
+    Status HandleRequest(const Request& request, Response* response);
 };
 
 REGISTER_REQUEST_HANDLER(EchoHandler);

--- a/http_handler.h
+++ b/http_handler.h
@@ -3,10 +3,11 @@
 
 
 #include <string>
+#include "response.h"
 
 namespace http {
 
-struct response;
+
 struct request;
 
 
@@ -21,7 +22,7 @@ public:
     virtual ~handler() {};    
 
     // Returns a response to the given request
-    virtual response handle_request(const request& req) = 0;
+    virtual Response handle_request(const request& req) = 0;
 
     std::string base_url; // Base url that corresponds to this handler
 };

--- a/http_handler_echo.cc
+++ b/http_handler_echo.cc
@@ -1,18 +1,18 @@
 #include "http_handler_echo.h"
 #include "http_request.h"
-#include "http_response.h"
+
 
 
 namespace http {
 
 // Echoes the request as plain text
-response handler_echo::handle_request(const request& req) {
+Response handler_echo::handle_request(const request& req) {
     // If base url is  not formatted correctly
     if (req.path.length() == 0 || req.path[0] != '/') {
-        return response::default_response(response::internal_server_error);
+        return Response::default_response(Response::internal_server_error);
     }
 
-    return http::response::plain_text_response(std::string(req.as_string));
+    return Response::plain_text_response(std::string(req.as_string));
 }
 
 } // namespace http

--- a/http_handler_echo.h
+++ b/http_handler_echo.h
@@ -2,11 +2,11 @@
 #define HTTP_HANDLER_ECHO_HPP
 
 #include "http_handler.h"
-
+#include "response.h"
 
 namespace http {
 
-struct response;
+
 struct request;
 
 
@@ -17,7 +17,7 @@ public:
     handler_echo(const std::string& base_url) : handler(base_url) {}; 
 
     // Echoes the request as plain text
-    response handle_request(const request& req);
+    Response handle_request(const request& req);
 };
 
 } // namespace http

--- a/http_handler_echo_test.cc
+++ b/http_handler_echo_test.cc
@@ -23,9 +23,9 @@ TEST_F(HttpHandlerEchoTest, SimpleEcho) {
     http::handler_echo hf("/echo");
     form_request("/echo/Makefile");
 
-    http::response res1 = hf.handle_request(r);
+    Response res1 = hf.handle_request(r);
 
-    http::response res2 = http::response::plain_text_response(std::string(r.as_string));
+    Response res2 = Response::plain_text_response(std::string(r.as_string));
 
     EXPECT_EQ(res1.headers[0].name, res1.headers[0].name);
     EXPECT_EQ(res2.headers[0].value, res1.headers[0].value);
@@ -44,13 +44,13 @@ TEST_F(HttpHandlerEchoTest, InvalidBaseUrl) {
     form_request("");
     http::handler_echo hf("/echo");
 
-    http::response res = hf.handle_request(r);
+    Response res = hf.handle_request(r);
 
-    EXPECT_EQ(http::response::status_code::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
 
     form_request("Makefile");
 
     res = hf.handle_request(r);
-    EXPECT_EQ(http::response::status_code::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
 
 }

--- a/http_handler_echo_test.cc
+++ b/http_handler_echo_test.cc
@@ -27,12 +27,12 @@ TEST_F(HttpHandlerEchoTest, SimpleEcho) {
 
     Response res2 = Response::plain_text_response(std::string(r.as_string));
 
-    EXPECT_EQ(res1.headers[0].name, res1.headers[0].name);
-    EXPECT_EQ(res2.headers[0].value, res1.headers[0].value);
-    EXPECT_EQ(res2.headers[1].name, res1.headers[1].name);
-    EXPECT_EQ(res2.headers[1].value, res1.headers[1].value);
-    EXPECT_EQ(res2.content, res1.content);
-    EXPECT_EQ(res2.status, res1.status);
+    EXPECT_EQ(res1.GetHeaders()[0].name, res1.GetHeaders()[0].name);
+    EXPECT_EQ(res2.GetHeaders()[0].value, res1.GetHeaders()[0].value);
+    EXPECT_EQ(res2.GetHeaders()[1].name, res1.GetHeaders()[1].name);
+    EXPECT_EQ(res2.GetHeaders()[1].value, res1.GetHeaders()[1].value);
+    EXPECT_EQ(res2.GetBody(), res1.GetBody());
+    EXPECT_EQ(res2.GetStatus(), res1.GetStatus());
     
 
 
@@ -46,11 +46,11 @@ TEST_F(HttpHandlerEchoTest, InvalidBaseUrl) {
 
     Response res = hf.handle_request(r);
 
-    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.GetStatus());
 
     form_request("Makefile");
 
     res = hf.handle_request(r);
-    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.GetStatus());
 
 }

--- a/http_handler_file.cc
+++ b/http_handler_file.cc
@@ -87,16 +87,21 @@ Response handler_file::handle_request(const request& req) {
 
     // Fill out the response to be sent to the client
     Response res;
-    res.status = Response::ok;
+    res.SetStatus(Response::ok);
+    std::string res_body;
+    // res.status = Response::ok;
     char buf[512];
     while (file.read(buf, sizeof(buf)).gcount() > 0) {
-        res.content.append(buf, file.gcount());
+        res_body.append(buf, file.gcount());
     }
-    res.headers.resize(2);
-    res.headers[0].name = "Content-Length";
-    res.headers[0].value = std::to_string(res.content.size());
-    res.headers[1].name = "Content-Type";
-    res.headers[1].value = extension_to_type(extension);
+    res.SetBody(res_body);
+    // res.headers.resize(2);
+    res.AddHeader("Content-Length", std::to_string(res.GetBody().size()));
+    res.AddHeader("Content-Type", extension_to_type(extension));
+    // res.headers[0].name = "Content-Length";
+    // res.headers[0].value = std::to_string(res.content.size());
+    // res.headers[1].name = "Content-Type";
+    // res.headers[1].value = extension_to_type(extension);
 
     return res;
 }

--- a/http_handler_file.cc
+++ b/http_handler_file.cc
@@ -4,7 +4,7 @@
 #include <fstream>
 #include "http_handler_file.h"
 #include "http_request.h"
-#include "http_response.h"
+#include "response.h"
 
 
 namespace http {
@@ -45,10 +45,10 @@ handler_file::handler_file(const std::string& doc_root, const std::string& base_
 
 
 // Responds with the file requested or an error page
-response handler_file::handle_request(const request& req) {
+Response handler_file::handle_request(const request& req) {
     // If base url is  not formatted correctly
     if (req.path.length() == 0 || req.path[0] != '/') {
-        return response::default_response(response::internal_server_error);
+        return Response::default_response(Response::internal_server_error);
     }
 
     // Determine the file extension
@@ -64,14 +64,14 @@ response handler_file::handle_request(const request& req) {
 
     // If the base url's do not match, this handler should not have been called
     if (reqs_base_url != this->base_url) {
-        return response::default_response(response::internal_server_error);
+        return Response::default_response(Response::internal_server_error);
     }
 
     std::string file_path = req.path.substr(this->base_url.length());
 
     // For if base url is provided by user but nothing else
     if (file_path == "") {
-        return response::default_response(response::not_found);
+        return Response::default_response(Response::not_found);
     }
 
     // Open the file to send back
@@ -82,12 +82,12 @@ response handler_file::handle_request(const request& req) {
 
     std::ifstream file(full_path.c_str(), std::ios::in | std::ios::binary);
     if (!file) {
-        return response::default_response(response::not_found);
+        return Response::default_response(Response::not_found);
     }
 
     // Fill out the response to be sent to the client
-    http::response res;
-    res.status = response::ok;
+    Response res;
+    res.status = Response::ok;
     char buf[512];
     while (file.read(buf, sizeof(buf)).gcount() > 0) {
         res.content.append(buf, file.gcount());

--- a/http_handler_file.h
+++ b/http_handler_file.h
@@ -18,7 +18,7 @@ public:
     handler_file(const std::string& doc_root, const std::string& base_url);
 
     // Responds with the file requested or an error page
-    response handle_request(const request& req);
+    Response handle_request(const request& req);
 
 private:
 

--- a/http_handler_file_test.cc
+++ b/http_handler_file_test.cc
@@ -27,7 +27,7 @@ TEST_F(HttpHandlerFileTest, FileExists) {
     // Creates a temporary file using name, replacing the last 6 X's 
     fd = mkstemp(name);
 
-    // Write the config_contents into the temp file
+    // Write the text_contents into the temp file
     write(fd, text_contents.c_str(), text_contents.size());
 
     form_request("/static1" + std::string(name));

--- a/http_handler_file_test.cc
+++ b/http_handler_file_test.cc
@@ -41,12 +41,12 @@ TEST_F(HttpHandlerFileTest, FileExists) {
     remove(name);
 
 
-    EXPECT_EQ("Content-Length", res.headers[0].name);
-    EXPECT_EQ(std::to_string(text_contents.size()), res.headers[0].value);
-    EXPECT_EQ("Content-Type", res.headers[1].name);
-    EXPECT_EQ("text/plain", res.headers[1].value);
-    EXPECT_EQ(text_contents, res.content);
-    EXPECT_EQ(Response::ResponseCode::ok, res.status);
+    EXPECT_EQ("Content-Length", res.GetHeaders()[0].name);
+    EXPECT_EQ(std::to_string(text_contents.size()), res.GetHeaders()[0].value);
+    EXPECT_EQ("Content-Type", res.GetHeaders()[1].name);
+    EXPECT_EQ("text/plain", res.GetHeaders()[1].value);
+    EXPECT_EQ(text_contents, res.GetBody());
+    EXPECT_EQ(Response::ResponseCode::ok, res.GetStatus());
 
     
 }
@@ -62,7 +62,7 @@ TEST_F(HttpHandlerFileTest, WrongHandlerCalled) {
     // Creates a temporary file using name, replacing the last 6 X's 
     fd = mkstemp(name);
 
-    // Write the config_contents into the temp file
+    // Write the configcontents into the temp file
     write(fd, text_contents.c_str(), text_contents.size());
 
     form_request("/static11" + std::string(name));
@@ -74,10 +74,10 @@ TEST_F(HttpHandlerFileTest, WrongHandlerCalled) {
     // Delete the file
     remove(name);
 
-    EXPECT_EQ("Content-Length", res.headers[0].name);
-    EXPECT_EQ("Content-Type", res.headers[1].name);
-    EXPECT_EQ("text/html", res.headers[1].value);
-    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
+    EXPECT_EQ("Content-Length", res.GetHeaders()[0].name);
+    EXPECT_EQ("Content-Type", res.GetHeaders()[1].name);
+    EXPECT_EQ("text/html", res.GetHeaders()[1].value);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.GetStatus());
     
 }
 
@@ -91,9 +91,9 @@ TEST_F(HttpHandlerFileTest, NoFileAskedFor) {
     Response res = hf.handle_request(r);
 
 
-    EXPECT_EQ("Content-Length", res.headers[0].name);
-    EXPECT_EQ("Content-Type", res.headers[1].name);
-    EXPECT_EQ(Response::ResponseCode::not_found, res.status);
+    EXPECT_EQ("Content-Length", res.GetHeaders()[0].name);
+    EXPECT_EQ("Content-Type", res.GetHeaders()[1].name);
+    EXPECT_EQ(Response::ResponseCode::not_found, res.GetStatus());
 
 }
 
@@ -107,9 +107,9 @@ TEST_F(HttpHandlerFileTest, FileDoesNotExit) {
     Response res = hf.handle_request(r);
 
 
-    EXPECT_EQ("Content-Length", res.headers[0].name);
-    EXPECT_EQ("Content-Type", res.headers[1].name);
-    EXPECT_EQ(Response::ResponseCode::not_found, res.status);
+    EXPECT_EQ("Content-Length", res.GetHeaders()[0].name);
+    EXPECT_EQ("Content-Type", res.GetHeaders()[1].name);
+    EXPECT_EQ(Response::ResponseCode::not_found, res.GetStatus());
 
 }
 
@@ -120,12 +120,12 @@ TEST_F(HttpHandlerFileTest, InvalidBaseUrl) {
 
     Response res = hf.handle_request(r);
 
-    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.GetStatus());
 
     form_request("Makefile");
 
     res = hf.handle_request(r);
-    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.GetStatus());
 
 }
 

--- a/http_handler_file_test.cc
+++ b/http_handler_file_test.cc
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 #include "http_handler_file.h"
 #include "http_request.h"
-#include "http_response.h"
+#include "response.h"
 
 
 
@@ -34,7 +34,7 @@ TEST_F(HttpHandlerFileTest, FileExists) {
     http::handler_file hf("/", "/static1");
 
 
-    http::response res = hf.handle_request(r);
+    Response res = hf.handle_request(r);
 
 
     //Delete the file
@@ -46,7 +46,7 @@ TEST_F(HttpHandlerFileTest, FileExists) {
     EXPECT_EQ("Content-Type", res.headers[1].name);
     EXPECT_EQ("text/plain", res.headers[1].value);
     EXPECT_EQ(text_contents, res.content);
-    EXPECT_EQ(http::response::status_code::ok, res.status);
+    EXPECT_EQ(Response::ResponseCode::ok, res.status);
 
     
 }
@@ -69,7 +69,7 @@ TEST_F(HttpHandlerFileTest, WrongHandlerCalled) {
     http::handler_file hf("/", "/static1");
 
 
-    http::response res = hf.handle_request(r);
+    Response res = hf.handle_request(r);
 
     // Delete the file
     remove(name);
@@ -77,7 +77,7 @@ TEST_F(HttpHandlerFileTest, WrongHandlerCalled) {
     EXPECT_EQ("Content-Length", res.headers[0].name);
     EXPECT_EQ("Content-Type", res.headers[1].name);
     EXPECT_EQ("text/html", res.headers[1].value);
-    EXPECT_EQ(http::response::status_code::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
     
 }
 
@@ -88,12 +88,12 @@ TEST_F(HttpHandlerFileTest, NoFileAskedFor) {
     http::handler_file hf("/", "/static1");
 
 
-    http::response res = hf.handle_request(r);
+    Response res = hf.handle_request(r);
 
 
     EXPECT_EQ("Content-Length", res.headers[0].name);
     EXPECT_EQ("Content-Type", res.headers[1].name);
-    EXPECT_EQ(http::response::status_code::not_found, res.status);
+    EXPECT_EQ(Response::ResponseCode::not_found, res.status);
 
 }
 
@@ -104,12 +104,12 @@ TEST_F(HttpHandlerFileTest, FileDoesNotExit) {
     http::handler_file hf("/", "/static1");
 
 
-    http::response res = hf.handle_request(r);
+    Response res = hf.handle_request(r);
 
 
     EXPECT_EQ("Content-Length", res.headers[0].name);
     EXPECT_EQ("Content-Type", res.headers[1].name);
-    EXPECT_EQ(http::response::status_code::not_found, res.status);
+    EXPECT_EQ(Response::ResponseCode::not_found, res.status);
 
 }
 
@@ -118,14 +118,14 @@ TEST_F(HttpHandlerFileTest, InvalidBaseUrl) {
     form_request("");
     http::handler_file hf("/", "/static1");
 
-    http::response res = hf.handle_request(r);
+    Response res = hf.handle_request(r);
 
-    EXPECT_EQ(http::response::status_code::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
 
     form_request("Makefile");
 
     res = hf.handle_request(r);
-    EXPECT_EQ(http::response::status_code::internal_server_error, res.status);
+    EXPECT_EQ(Response::ResponseCode::internal_server_error, res.status);
 
 }
 

--- a/http_response.cc
+++ b/http_response.cc
@@ -263,9 +263,6 @@ std::vector<boost::asio::const_buffer> response::to_buffers() const {
     return buffers;
 }
 
-
-
-
 std::string response::ToString() const {
     std::string response_string = "";
     response_string += status_string::to_string(status);
@@ -280,7 +277,6 @@ std::string response::ToString() const {
     response_string += (misc_string::crlf);
     response_string += (content);
     return response_string;
-
 
 }
 

--- a/http_response.h
+++ b/http_response.h
@@ -42,6 +42,8 @@ struct response {
     // Converts the response into buffers so that it can be sent to the client
     std::vector<boost::asio::const_buffer> to_buffers() const;
 
+    std::string ToString() const;
+
     status_code         status;  // Status code for the response
     std::vector<header> headers; // Headers included in the response
     std::string         content; // Body of the response

--- a/new_example_config
+++ b/new_example_config
@@ -1,0 +1,17 @@
+#Note:
+#  Order of path blocks in the config file doesn't matter.
+#  Matching is by longest prefix.
+#  Duplicate paths in the config are illegal.
+
+# This is a comment.
+
+port 2020;  # This is also a comment.
+
+path / StaticHandler {
+  root /foo/bar;
+}
+
+path /echo EchoHandler {}
+
+# Default response handler if no handlers match.
+default NotFoundHandler {}

--- a/registerer_main.cc
+++ b/registerer_main.cc
@@ -6,7 +6,6 @@
 
 int main(int arc, char** argv) {
 
-
   NginxConfig config;
   std::string str;
   Request request;

--- a/registerer_main.cc
+++ b/registerer_main.cc
@@ -16,7 +16,7 @@ int main(int arc, char** argv) {
   handler->Init(str, config);
   handler->HandleRequest(request, &response);
   handler = RequestHandler::CreateByName("StaticFileHandler");
-  handler->HandleRequest(request, &response);
   handler->Init(str, config);
+  handler->HandleRequest(request, &response);
   return 0;
 }

--- a/registerer_main.cc
+++ b/registerer_main.cc
@@ -1,0 +1,22 @@
+#include "request_handler.h"
+#include "response.h"
+#include "request.h"
+#include "config_parser.h"
+#include <string>
+
+int main(int arc, char** argv) {
+
+
+  NginxConfig config;
+  std::string str;
+  Request request;
+  Response response;
+
+  auto handler = RequestHandler::CreateByName("EchoHandler");
+  handler->Init(str, config);
+  handler->HandleRequest(request, &response);
+  handler = RequestHandler::CreateByName("StaticFileHandler");
+  handler->HandleRequest(request, &response);
+  handler->Init(str, config);
+  return 0;
+}

--- a/request.h
+++ b/request.h
@@ -1,0 +1,25 @@
+// Represents an HTTP Request.
+//
+// Usage:
+//   auto request = Request::Parse(raw_request);
+
+#ifndef REQUEST_H
+#define REQUEST_H
+
+class Request {
+ public:
+  static unique_ptr<Request> Parse(const std::string& raw_request);
+
+  std::string raw_request() const;
+  std::string method() const;
+  std::string uri() const;
+  std::string version() const;
+
+  using Headers = std::vector<std::pair<std::string, std::string>>;
+  Headers headers() const;
+
+  std::string body() const;
+};
+
+
+#endif // REQUEST_H

--- a/request.h
+++ b/request.h
@@ -6,9 +6,12 @@
 #ifndef REQUEST_H
 #define REQUEST_H
 
+
+
+
 class Request {
  public:
-  static unique_ptr<Request> Parse(const std::string& raw_request);
+  static std::unique_ptr<Request> Parse(const std::string& raw_request);
 
   std::string raw_request() const;
   std::string method() const;

--- a/request.h
+++ b/request.h
@@ -6,22 +6,19 @@
 #ifndef REQUEST_H
 #define REQUEST_H
 
-
-
-
 class Request {
  public:
-  static std::unique_ptr<Request> Parse(const std::string& raw_request);
+    static std::unique_ptr<Request> Parse(const std::string& raw_request);
 
-  std::string raw_request() const;
-  std::string method() const;
-  std::string uri() const;
-  std::string version() const;
+    std::string raw_request() const;
+    std::string method() const;
+    std::string uri() const;
+    std::string version() const;
 
-  using Headers = std::vector<std::pair<std::string, std::string>>;
-  Headers headers() const;
+    using Headers = std::vector<std::pair<std::string, std::string>>;
+    Headers headers() const;
 
-  std::string body() const;
+    std::string body() const;
 };
 
 

--- a/request_handler.cc
+++ b/request_handler.cc
@@ -1,0 +1,11 @@
+#include "request_handler.h"
+
+std::map<std::string, RequestHandler* (*)(void)>* request_handler_builders = nullptr;
+
+RequestHandler* RequestHandler::CreateByName(const char* type) {
+  const auto type_and_builder = request_handler_builders->find(type);
+  if (type_and_builder == request_handler_builders->end()) {
+    return nullptr;
+  }
+  return (*type_and_builder->second)();
+}

--- a/request_handler.h
+++ b/request_handler.h
@@ -2,47 +2,10 @@
 // and add private data as appropriate. You may also need to modify or extend
 // the API when implementing the reverse proxy. Use your good judgment.
 
-// Represents an HTTP Request.
-//
-// Usage:
-//   auto request = Request::Parse(raw_request);
-class Request {
- public:
-  static unique_ptr<Request> Parse(const std::string& raw_request);
+#ifndef REQUEST_HANDLER_H
+#define REQUEST_HANDLER_H
 
-  std::string raw_request() const;
-  std::string method() const;
-  std::string uri() const;
-  std::string version() const;
 
-  using Headers = std::vector<std::pair<std::string, std::string>>;
-  Headers headers() const;
-
-  std::string body() const;
-};
-
-// Represents an HTTP response.
-//
-// Usage:
-//   Response r;
-//   r.SetStatus(RESPONSE_200);
-//   r.SetBody(...);
-//   return r.ToString();
-//
-// Constructed by the RequestHandler, after which the server should call ToString
-// to serialize.
-class Response {
- public:
-  enum ResponseCode {
-    // Define your HTTP response codes here.
-  };
-  
-  void SetStatus(const ResponseCode response_code);
-  void AddHeader(const std::string& header_name, const std::string& header_value);
-  void SetBody(const std::string& body);
-  
-  std::string ToString();
-};
 
 // Represents the parent of all request handlers. Implementations should expect to
 // be long lived and created at server constrution.
@@ -66,3 +29,7 @@ class RequestHandler {
   virtual Status HandleRequest(const Request& request,
                                Response* response) = 0;
 };
+
+
+
+#endif // REQUEST_HANDLER_H

--- a/request_handler.h
+++ b/request_handler.h
@@ -5,16 +5,24 @@
 #ifndef REQUEST_HANDLER_H
 #define REQUEST_HANDLER_H
 
-
+#include <map>
+#include <memory>
+#include <string>
+#include "config_parser.h"
+#include "request.h"
+#include "response.h"
 
 // Represents the parent of all request handlers. Implementations should expect to
 // be long lived and created at server constrution.
 class RequestHandler {
  public:
   enum Status {
-    OK = 0;
+    OK = 0
     // Define your status codes here.
   };
+
+
+  static RequestHandler* CreateByName(const char* type);
   
   // Initializes the handler. Returns true if successful.
   // uri_prefix is the value in the config file that this handler will run for.
@@ -29,6 +37,35 @@ class RequestHandler {
   virtual Status HandleRequest(const Request& request,
                                Response* response) = 0;
 };
+
+
+
+
+// Notes:
+// * The trick here is that you can declare an object at file scope, but you
+//   can't do anything else, such as set a map key. But you can get around this
+//   by creating a class that does work in its constructor.
+// * request_handler_builders must be a pointer. Otherwise, it won't necessarily
+//   exist when the RequestHandlerRegisterer constructor gets called.
+
+extern std::map<std::string, RequestHandler* (*)(void)>* request_handler_builders;
+template<typename T>
+class RequestHandlerRegisterer {
+ public:
+  RequestHandlerRegisterer(const std::string& type) {
+    if (request_handler_builders == nullptr) {
+      request_handler_builders = new std::map<std::string, RequestHandler* (*)(void)>;
+    }
+    (*request_handler_builders)[type] = RequestHandlerRegisterer::Create;
+  }
+  static RequestHandler* Create() {
+    return new T;
+  }
+};
+#define REGISTER_REQUEST_HANDLER(ClassName) \
+  static RequestHandlerRegisterer<ClassName> ClassName##__registerer(#ClassName)
+
+
 
 
 

--- a/request_handler.h
+++ b/request_handler.h
@@ -1,0 +1,68 @@
+// For the Request and Response classes, you need to implement the methods
+// and add private data as appropriate. You may also need to modify or extend
+// the API when implementing the reverse proxy. Use your good judgment.
+
+// Represents an HTTP Request.
+//
+// Usage:
+//   auto request = Request::Parse(raw_request);
+class Request {
+ public:
+  static unique_ptr<Request> Parse(const std::string& raw_request);
+
+  std::string raw_request() const;
+  std::string method() const;
+  std::string uri() const;
+  std::string version() const;
+
+  using Headers = std::vector<std::pair<std::string, std::string>>;
+  Headers headers() const;
+
+  std::string body() const;
+};
+
+// Represents an HTTP response.
+//
+// Usage:
+//   Response r;
+//   r.SetStatus(RESPONSE_200);
+//   r.SetBody(...);
+//   return r.ToString();
+//
+// Constructed by the RequestHandler, after which the server should call ToString
+// to serialize.
+class Response {
+ public:
+  enum ResponseCode {
+    // Define your HTTP response codes here.
+  };
+  
+  void SetStatus(const ResponseCode response_code);
+  void AddHeader(const std::string& header_name, const std::string& header_value);
+  void SetBody(const std::string& body);
+  
+  std::string ToString();
+};
+
+// Represents the parent of all request handlers. Implementations should expect to
+// be long lived and created at server constrution.
+class RequestHandler {
+ public:
+  enum Status {
+    OK = 0;
+    // Define your status codes here.
+  };
+  
+  // Initializes the handler. Returns true if successful.
+  // uri_prefix is the value in the config file that this handler will run for.
+  // config is the contents of the child block for this handler ONLY.
+  virtual Status Init(const std::string& uri_prefix,
+                      const NginxConfig& config) = 0;
+
+  // Handles an HTTP request, and generates a response. Returns a response code
+  // indicating success or failure condition. If ResponseCode is not OK, the
+  // contents of the response object are undefined, and the server will return
+  // HTTP code 500.
+  virtual Status HandleRequest(const Request& request,
+                               Response* response) = 0;
+};

--- a/response.cc
+++ b/response.cc
@@ -1,10 +1,69 @@
-// This file is based on the Boost HTTP server example at
-//  http://www.boost.org/doc/libs/1_55_0/doc/html/boost_asio/examples/cpp11_examples.html
-
-#include "http_response.h"
+#include "response.h"
 
 
-namespace http {
+
+
+void Response::SetStatus(const ResponseCode Response_code) {
+    this->status = Response_code;
+}
+
+void Response::AddHeader(const std::string& header_name, const std::string& header_value) {
+    this->headers.push_back(std::make_pair(header_name, header_value));
+
+}
+
+void Response::SetBody(const std::string& body) {
+    this->content = body;
+
+}
+
+
+namespace misc_string {
+
+// Strings used in forming an HTTP Response
+const char field_separator[] = { ':', ' ' };
+const char crlf[] = { '\r', '\n' };
+
+} // namespace helper_strings
+
+
+namespace status_string {
+
+// Status lines for every status code in HTTP/1.0
+const std::string ok =
+    "HTTP/1.0 200 OK\r\n";
+const std::string created =
+    "HTTP/1.0 201 Created\r\n";
+const std::string accepted =
+    "HTTP/1.0 202 Accepted\r\n";
+const std::string no_content =
+    "HTTP/1.0 204 No Content\r\n";
+const std::string moved_permanently =
+    "HTTP/1.0 301 Moved Permanently\r\n";
+const std::string moved_temporarily =
+    "HTTP/1.0 302 Moved Temporarily\r\n";
+const std::string not_modified =
+    "HTTP/1.0 304 Not Modified\r\n";
+const std::string bad_request =
+    "HTTP/1.0 400 Bad Request\r\n";
+const std::string unauthorized =
+    "HTTP/1.0 401 Unauthorized\r\n";
+const std::string forbidden =
+    "HTTP/1.0 403 Forbidden\r\n";
+const std::string not_found =
+    "HTTP/1.0 404 Not Found\r\n";
+const std::string internal_server_error =
+    "HTTP/1.0 500 Internal Server Error\r\n";
+const std::string not_implemented =
+    "HTTP/1.0 501 Not Implemented\r\n";
+const std::string bad_gateway =
+    "HTTP/1.0 502 Bad Gateway\r\n";
+const std::string service_unavailable =
+    "HTTP/1.0 503 Service Unavailable\r\n";
+
+} // namespace status_string
+
+
 
 namespace default_responses{
 
@@ -83,82 +142,82 @@ const char service_unavailable[] =
     "</html>";
 
 // Gets default message body for a given status code
-std::string to_string(response::status_code status)
+std::string to_string(Response::ResponseCode status)
 {
     switch (status)
     {
-    case response::ok:
+    case Response::ok:
         return ok;
-    case response::created:
+    case Response::created:
         return created;
-    case response::accepted:
+    case Response::accepted:
         return accepted;
-    case response::no_content:
+    case Response::no_content:
         return no_content;
-    case response::moved_permanently:
+    case Response::moved_permanently:
         return moved_permanently;
-    case response::moved_temporarily:
+    case Response::moved_temporarily:
         return moved_temporarily;
-    case response::not_modified:
+    case Response::not_modified:
         return not_modified;
-    case response::bad_request:
+    case Response::bad_request:
         return bad_request;
-    case response::unauthorized:
+    case Response::unauthorized:
         return unauthorized;
-    case response::forbidden:
+    case Response::forbidden:
         return forbidden;
-    case response::not_found:
+    case Response::not_found:
         return not_found;
-    case response::internal_server_error:
+    case Response::internal_server_error:
         return internal_server_error;
-    case response::not_implemented:
+    case Response::not_implemented:
         return not_implemented;
-    case response::bad_gateway:
+    case Response::bad_gateway:
         return bad_gateway;
-    case response::service_unavailable:
+    case Response::service_unavailable:
         return service_unavailable;
     default:
         return internal_server_error;
     }
 }
 
-} // namespace default_responses
+} // namespace default_Responses
 
 
 namespace status_string {
 
 // Gets status line for a given status code
-boost::asio::const_buffer to_buffer(response::status_code status) {
+boost::asio::const_buffer to_buffer(Response::ResponseCode status) {
     switch (status) {
-    case response::ok:
+    case Response::ok:
         return boost::asio::buffer(ok);
-    case response::created:
+    case Response::created:
         return boost::asio::buffer(created);
-    case response::accepted:
+    case Response::accepted:
         return boost::asio::buffer(accepted);
-    case response::no_content:
+    case Response::no_content:
         return boost::asio::buffer(no_content);
-    case response::moved_permanently:
+    case Response::moved_permanently:
         return boost::asio::buffer(moved_permanently);
-    case response::moved_temporarily:
+    case Response::moved_temporarily:
         return boost::asio::buffer(moved_temporarily);
-    case response::not_modified:
+    case Response::not_modified:
         return boost::asio::buffer(not_modified);
-    case response::bad_request:
+    case Response::bad_request:
         return boost::asio::buffer(bad_request);
-    case response::unauthorized:
+    case Response::unauthorized:
         return boost::asio::buffer(unauthorized);
-    case response::forbidden:
+    case Response::forbidden:
         return boost::asio::buffer(forbidden);
-    case response::not_found:
+    case Response::not_found:
         return boost::asio::buffer(not_found);
-    case response::internal_server_error:
+    case Response::internal_server_error:
         return boost::asio::buffer(internal_server_error);
-    case response::not_implemented:
+    case Response::not_implemented:
         return boost::asio::buffer(not_implemented);
-    case response::bad_gateway:
+    case Response::bad_gateway:
         return boost::asio::buffer(bad_gateway);
-    case response::service_unavailable:
+    case Response::service_unavailable:
         return boost::asio::buffer(service_unavailable);
     default:
         return boost::asio::buffer(internal_server_error);
@@ -167,37 +226,37 @@ boost::asio::const_buffer to_buffer(response::status_code status) {
 
 
 // Gets status line for a given status code
-std::string to_string(response::status_code status) {
+std::string to_string(Response::ResponseCode status) {
     switch (status) {
-    case response::ok:
+    case Response::ok:
         return (ok);
-    case response::created:
+    case Response::created:
         return (created);
-    case response::accepted:
+    case Response::accepted:
         return (accepted);
-    case response::no_content:
+    case Response::no_content:
         return (no_content);
-    case response::moved_permanently:
+    case Response::moved_permanently:
         return (moved_permanently);
-    case response::moved_temporarily:
+    case Response::moved_temporarily:
         return (moved_temporarily);
-    case response::not_modified:
+    case Response::not_modified:
         return (not_modified);
-    case response::bad_request:
+    case Response::bad_request:
         return (bad_request);
-    case response::unauthorized:
+    case Response::unauthorized:
         return (unauthorized);
-    case response::forbidden:
+    case Response::forbidden:
         return (forbidden);
-    case response::not_found:
+    case Response::not_found:
         return (not_found);
-    case response::internal_server_error:
+    case Response::internal_server_error:
         return (internal_server_error);
-    case response::not_implemented:
+    case Response::not_implemented:
         return (not_implemented);
-    case response::bad_gateway:
+    case Response::bad_gateway:
         return (bad_gateway);
-    case response::service_unavailable:
+    case Response::service_unavailable:
         return (service_unavailable);
     default:
         return (internal_server_error);
@@ -208,9 +267,9 @@ std::string to_string(response::status_code status) {
 } // namespace status_string
 
 
-// Creates a default response for a given status code
-response response::default_response(response::status_code status) {
-    response r;
+// Creates a default Response for a given status code
+Response Response::default_response(Response::ResponseCode status) {
+    Response r;
     r.status = status;
     r.content = default_responses::to_string(status);
     r.headers.resize(2);
@@ -221,10 +280,10 @@ response response::default_response(response::status_code status) {
     return r;
 }
 
-// Creates a text/plain response for the given text or html
-response response::plain_text_response(std::string&& text) {
-    response r;
-    r.status = response::ok;
+// Creates a text/plain Response for the given text or html
+Response Response::plain_text_response(std::string&& text) {
+    Response r;
+    r.status = Response::ok;
     r.content = std::move(text);
     r.headers.resize(2);
     r.headers[0].name = "Content-Length";
@@ -234,10 +293,10 @@ response response::plain_text_response(std::string&& text) {
     return r;
 }
 
-// Creates a text/html response for the given text or html
-response response::html_response(std::string&& html) {
-    response r;
-    r.status = response::ok;
+// Creates a text/html Response for the given text or html
+Response Response::html_response(std::string&& html) {
+    Response r;
+    r.status = Response::ok;
     r.content = std::move(html);
     r.headers.resize(2);
     r.headers[0].name = "Content-Length";
@@ -247,15 +306,15 @@ response response::html_response(std::string&& html) {
     return r;
 }
 
-// Converts the response into buffers so that it can be sent to the client
-std::vector<boost::asio::const_buffer> response::to_buffers() const {
+// Converts the Response into buffers so that it can be sent to the client
+std::vector<boost::asio::const_buffer> Response::to_buffers() const {
     std::vector<boost::asio::const_buffer> buffers;
     buffers.push_back(status_string::to_buffer(status));
     for (std::size_t i = 0; i < headers.size(); ++i) {
-        const header& h = headers[i];
-        buffers.push_back(boost::asio::buffer(h.name));
+        // const header& h = headers[i];
+        buffers.push_back(boost::asio::buffer(headers[i].name));
         buffers.push_back(boost::asio::buffer(misc_string::field_separator));
-        buffers.push_back(boost::asio::buffer(h.value));
+        buffers.push_back(boost::asio::buffer(headers[i].value));
         buffers.push_back(boost::asio::buffer(misc_string::crlf));
     }
     buffers.push_back(boost::asio::buffer(misc_string::crlf));
@@ -263,29 +322,21 @@ std::vector<boost::asio::const_buffer> response::to_buffers() const {
     return buffers;
 }
 
-
-
-
-std::string response::ToString() const {
-    std::string response_string = "";
-    response_string += status_string::to_string(status);
+std::string Response::ToString() const {
+    std::string Response_string = "";
+    Response_string += status_string::to_string(status);
     for (std::size_t i = 0; i < headers.size(); ++i) {
         const header& h = headers[i];
-        response_string += (h.name);
-        response_string += std::string(misc_string::field_separator, sizeof(misc_string::field_separator));
-        response_string += (h.value);
-        response_string += std::string(misc_string::crlf, sizeof(misc_string::crlf));
+        Response_string += (h.name);
+        Response_string += std::string(misc_string::field_separator, sizeof(misc_string::field_separator));
+        Response_string += (h.value);
+        Response_string += std::string(misc_string::crlf, sizeof(misc_string::crlf));
     }
 
-    response_string += (misc_string::crlf);
-    response_string += (content);
-    return response_string;
+    Response_string += (misc_string::crlf);
+    Response_string += (content);
+    return Response_string;
 
 
 }
-
-
-
-} // namespace http
-
 

--- a/response.cc
+++ b/response.cc
@@ -319,22 +319,6 @@ Response Response::html_response(std::string&& html) {
     return r;
 }
 
-// Converts the Response into buffers so that it can be sent to the client
-std::vector<boost::asio::const_buffer> Response::to_buffers() const {
-    std::vector<boost::asio::const_buffer> buffers;
-    buffers.push_back(status_string::to_buffer(status));
-    for (std::size_t i = 0; i < headers.size(); ++i) {
-        // const header& h = headers[i];
-        buffers.push_back(boost::asio::buffer(headers[i].name));
-        buffers.push_back(boost::asio::buffer(misc_string::field_separator));
-        buffers.push_back(boost::asio::buffer(headers[i].value));
-        buffers.push_back(boost::asio::buffer(misc_string::crlf));
-    }
-    buffers.push_back(boost::asio::buffer(misc_string::crlf));
-    buffers.push_back(boost::asio::buffer(content));
-    return buffers;
-}
-
 std::string Response::ToString() const {
     std::string Response_string = "";
     Response_string += status_string::to_string(status);

--- a/response.cc
+++ b/response.cc
@@ -18,6 +18,19 @@ void Response::SetBody(const std::string& body) {
 }
 
 
+Response::Headers Response::GetHeaders() const {
+    return this->headers;
+}
+
+Response::ResponseCode Response::GetStatus() const {
+    return this->status;
+}
+
+std::string Response::GetBody() const {
+    return this->content;
+}
+
+
 namespace misc_string {
 
 // Strings used in forming an HTTP Response

--- a/response.cc
+++ b/response.cc
@@ -9,14 +9,11 @@ void Response::SetStatus(const ResponseCode Response_code) {
 
 void Response::AddHeader(const std::string& header_name, const std::string& header_value) {
     this->headers.push_back(std::make_pair(header_name, header_value));
-
 }
 
 void Response::SetBody(const std::string& body) {
     this->content = body;
-
 }
-
 
 Response::Headers Response::GetHeaders() const {
     return this->headers;
@@ -320,20 +317,18 @@ Response Response::html_response(std::string&& html) {
 }
 
 std::string Response::ToString() const {
-    std::string Response_string = "";
-    Response_string += status_string::to_string(status);
+    std::string response_string = "";
+    response_string += status_string::to_string(status);
     for (std::size_t i = 0; i < headers.size(); ++i) {
         const header& h = headers[i];
-        Response_string += (h.name);
-        Response_string += std::string(misc_string::field_separator, sizeof(misc_string::field_separator));
-        Response_string += (h.value);
-        Response_string += std::string(misc_string::crlf, sizeof(misc_string::crlf));
+        response_string += (h.name);
+        response_string += std::string(misc_string::field_separator, sizeof(misc_string::field_separator));
+        response_string += (h.value);
+        response_string += std::string(misc_string::crlf, sizeof(misc_string::crlf));
     }
 
-    Response_string += (misc_string::crlf);
-    Response_string += (content);
-    return Response_string;
-
-
+    response_string += (misc_string::crlf);
+    response_string += (content);
+    return response_string;
 }
 

--- a/response.h
+++ b/response.h
@@ -18,6 +18,7 @@ class Response {
  public:
   enum ResponseCode {
     // Define your HTTP response codes here.
+    OK = 200
   };
   
   void SetStatus(const ResponseCode response_code);

--- a/response.h
+++ b/response.h
@@ -24,57 +24,59 @@ typedef std::pair<std::string, std::string> header;
 
 
 class Response {
- public:
-  enum ResponseCode {
-    // Define your HTTP response codes here.
-    ok = 200,
-    created = 201,
-    accepted = 202,
-    no_content = 204,
-    moved_permanently = 301,
-    moved_temporarily = 302,
-    not_modified = 304,
-    bad_request = 400,
-    unauthorized = 401,
-    forbidden = 403,
-    not_found = 404,
-    internal_server_error = 500,
-    not_implemented = 501,
-    bad_gateway = 502,
-    service_unavailable = 503
-  };
+public:
+    enum ResponseCode {
+        // Define your HTTP response codes here.
+        ok = 200,
+        created = 201,
+        accepted = 202,
+        no_content = 204,
+        moved_permanently = 301,
+        moved_temporarily = 302,
+        not_modified = 304,
+        bad_request = 400,
+        unauthorized = 401,
+        forbidden = 403,
+        not_found = 404,
+        internal_server_error = 500,
+        not_implemented = 501,
+        bad_gateway = 502,
+        service_unavailable = 503
+    };
 
     // Creates a default response for a given status code
-  static Response default_response(ResponseCode status);
+    static Response default_response(ResponseCode status);
 
-  // Creates a plain text response for the given text
-  static Response plain_text_response(std::string&& text);
+    // Creates a plain text response for the given text
+    static Response plain_text_response(std::string&& text);
 
-  // Creates a text/html response for the given html
-  static Response html_response(std::string&& html);
+    // Creates a text/html response for the given html
+    static Response html_response(std::string&& html);   
 
-  
+    // Sets the status of the repsonse
+    void SetStatus(const ResponseCode response_code);
 
-  
-  void SetStatus(const ResponseCode response_code);
-  void AddHeader(const std::string& header_name, const std::string& header_value);
-  void SetBody(const std::string& body);
-  
-  std::string ToString() const;
+    // Adds a header where the first field is the name of the header and the second is the value of the header
+    void AddHeader(const std::string& header_name, const std::string& header_value);
 
+    // Sets the body of the response
+    void SetBody(const std::string& body);
+    
+    // Converts response to a HTTP string
+    std::string ToString() const;
 
-
-  using Headers = std::vector<std::pair<std::string, std::string>>;
-  Headers GetHeaders() const;
-  ResponseCode GetStatus() const;
-  std::string GetBody() const;
-
-
+    using Headers = std::vector<std::pair<std::string, std::string>>;
+    // Get the headers of the response
+    Headers GetHeaders() const;
+    // Get the status of the response
+    ResponseCode GetStatus() const;
+    // Get the body of the response
+    std::string GetBody() const;
 
  private:
-  ResponseCode status; // Status code of the http response
-  std::vector<std::pair<std::string, std::string>> headers; // Vector of headers for the http response
-  std::string content; // Body of http response
+    ResponseCode status; // Status code of the http response
+    std::vector<std::pair<std::string, std::string>> headers; // Vector of headers for the http response
+    std::string content; // Body of http response
 
 
 };

--- a/response.h
+++ b/response.h
@@ -1,0 +1,31 @@
+// Represents an HTTP response.
+//
+// Usage:
+//   Response r;
+//   r.SetStatus(RESPONSE_200);
+//   r.SetBody(...);
+//   return r.ToString();
+//
+// Constructed by the RequestHandler, after which the server should call ToString
+// to serialize.
+
+
+#ifndef RESPONSE_H
+#define RESPONSE_H
+
+
+class Response {
+ public:
+  enum ResponseCode {
+    // Define your HTTP response codes here.
+  };
+  
+  void SetStatus(const ResponseCode response_code);
+  void AddHeader(const std::string& header_name, const std::string& header_value);
+  void SetBody(const std::string& body);
+  
+  std::string ToString();
+};
+
+
+#endif // RESPONSE_H

--- a/response.h
+++ b/response.h
@@ -53,9 +53,7 @@ class Response {
   // Creates a text/html response for the given html
   static Response html_response(std::string&& html);
 
-  // Converts the response into buffers so that it can be sent to the client
-  std::vector<boost::asio::const_buffer> to_buffers() const;
-
+  
 
   
   void SetStatus(const ResponseCode response_code);

--- a/response.h
+++ b/response.h
@@ -43,6 +43,20 @@ class Response {
     bad_gateway = 502,
     service_unavailable = 503
   };
+
+    // Creates a default response for a given status code
+  static Response default_response(ResponseCode status);
+
+  // Creates a plain text response for the given text
+  static Response plain_text_response(std::string&& text);
+
+  // Creates a text/html response for the given html
+  static Response html_response(std::string&& html);
+
+  // Converts the response into buffers so that it can be sent to the client
+  std::vector<boost::asio::const_buffer> to_buffers() const;
+
+
   
   void SetStatus(const ResponseCode response_code);
   void AddHeader(const std::string& header_name, const std::string& header_value);
@@ -51,20 +65,15 @@ class Response {
   std::string ToString() const;
 
 
-// Creates a default response for a given status code
-    static Response default_response(ResponseCode status);
 
-    // Creates a plain text response for the given text
-    static Response plain_text_response(std::string&& text);
-
-    // Creates a text/html response for the given html
-    static Response html_response(std::string&& html);
-
-    // Converts the response into buffers so that it can be sent to the client
-    std::vector<boost::asio::const_buffer> to_buffers() const;
+  using Headers = std::vector<std::pair<std::string, std::string>>;
+  Headers GetHeaders() const;
+  ResponseCode GetStatus() const;
+  std::string GetBody() const;
 
 
- // private:
+
+ private:
   ResponseCode status; // Status code of the http response
   std::vector<std::pair<std::string, std::string>> headers; // Vector of headers for the http response
   std::string content; // Body of http response

--- a/response.h
+++ b/response.h
@@ -13,20 +13,78 @@
 #ifndef RESPONSE_H
 #define RESPONSE_H
 
+#include <boost/asio.hpp>
+#include <string>
+#include <vector>
+
+#define name first
+#define value second
+
+typedef std::pair<std::string, std::string> header;
+
 
 class Response {
  public:
   enum ResponseCode {
     // Define your HTTP response codes here.
-    OK = 200
+    ok = 200,
+    created = 201,
+    accepted = 202,
+    no_content = 204,
+    moved_permanently = 301,
+    moved_temporarily = 302,
+    not_modified = 304,
+    bad_request = 400,
+    unauthorized = 401,
+    forbidden = 403,
+    not_found = 404,
+    internal_server_error = 500,
+    not_implemented = 501,
+    bad_gateway = 502,
+    service_unavailable = 503
   };
   
   void SetStatus(const ResponseCode response_code);
   void AddHeader(const std::string& header_name, const std::string& header_value);
   void SetBody(const std::string& body);
   
-  std::string ToString();
+  std::string ToString() const;
+
+
+// Creates a default response for a given status code
+    static Response default_response(ResponseCode status);
+
+    // Creates a plain text response for the given text
+    static Response plain_text_response(std::string&& text);
+
+    // Creates a text/html response for the given html
+    static Response html_response(std::string&& html);
+
+    // Converts the response into buffers so that it can be sent to the client
+    std::vector<boost::asio::const_buffer> to_buffers() const;
+
+
+ // private:
+  ResponseCode status; // Status code of the http response
+  std::vector<std::pair<std::string, std::string>> headers; // Vector of headers for the http response
+  std::string content; // Body of http response
+
+
 };
+
+
+
+
+
+namespace default_responses {
+
+// Gets default message body for a given status code
+std::string to_string(Response::ResponseCode status);
+
+} // namespace default_responses
+
+
+
 
 
 #endif // RESPONSE_H

--- a/response_test.cc
+++ b/response_test.cc
@@ -1,0 +1,160 @@
+#include "gtest/gtest.h"
+#include "response.h"
+
+
+class ResponseDefaultResponseTest : public ::testing::Test {
+protected:
+
+    void VerifyContents(Response::ResponseCode status) {
+        r = Response::default_response(status);
+
+        ASSERT_EQ(status, r.status);
+        ASSERT_EQ(default_responses::to_string(r.status), r.content);
+        ASSERT_EQ(2, r.headers.size());
+        EXPECT_EQ("Content-Length", r.headers[0].name);
+        EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+        EXPECT_EQ("Content-Type", r.headers[1].name);
+        EXPECT_EQ("text/html", r.headers[1].value);
+    }
+
+    Response r;
+};
+
+
+TEST_F(ResponseDefaultResponseTest, OkStatus) {
+    VerifyContents(Response::ResponseCode::ok);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, CreatedStatus) {
+    VerifyContents(Response::ResponseCode::created);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, AcceptedStatus) {
+    VerifyContents(Response::ResponseCode::accepted);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, NoContentStatus) {
+    VerifyContents(Response::ResponseCode::no_content);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, MovedPermanentlyStatus) {
+    VerifyContents(Response::ResponseCode::moved_permanently);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, MovedTemporarilyStatus) {
+    VerifyContents(Response::ResponseCode::moved_temporarily);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, NotModifiedStatus) {
+    VerifyContents(Response::ResponseCode::not_modified);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, BadRequestStatus) {
+    VerifyContents(Response::ResponseCode::bad_request);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, UnauthorizedStatus) {
+    VerifyContents(Response::ResponseCode::unauthorized);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, ForbiddenStatus) {
+    VerifyContents(Response::ResponseCode::forbidden);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, NotFoundStatus) {
+    VerifyContents(Response::ResponseCode::not_found);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, InternalServerErrorStatus) {
+    VerifyContents(Response::ResponseCode::internal_server_error);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, NotImplementederrorStatus) {
+    VerifyContents(Response::ResponseCode::not_implemented);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, BadGatewayStatus) {
+    VerifyContents(Response::ResponseCode::bad_gateway);
+}
+
+
+TEST_F(ResponseDefaultResponseTest, ServiceUnavailableStatus) {
+    VerifyContents(Response::ResponseCode::service_unavailable);
+}
+
+
+TEST(ResponseTest, html) {
+    Response r = Response::html_response(
+        default_responses::to_string(Response::ResponseCode::ok));
+
+    ASSERT_EQ(Response::ResponseCode::ok, r.status);
+    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.content);
+    ASSERT_EQ(2, r.headers.size());
+    EXPECT_EQ("Content-Length", r.headers[0].name);
+    EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+    EXPECT_EQ("Content-Type", r.headers[1].name);
+    EXPECT_EQ("text/html", r.headers[1].value);
+}
+
+
+TEST(ResponseTest, plain) {
+    Response r = Response::plain_text_response(
+        default_responses::to_string(Response::ResponseCode::ok));
+
+    ASSERT_EQ(Response::ResponseCode::ok, r.status);
+    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.content);
+    ASSERT_EQ(2, r.headers.size());
+    EXPECT_EQ("Content-Length", r.headers[0].name);
+    EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+    EXPECT_EQ("Content-Type", r.headers[1].name);
+    EXPECT_EQ("text/plain", r.headers[1].value);
+}
+
+
+TEST(ToBufferTest, generaltest) {
+    Response r = Response::plain_text_response(
+        default_responses::to_string(Response::ResponseCode::ok));
+
+    ASSERT_EQ(Response::ResponseCode::ok, r.status);
+    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.content);
+    ASSERT_EQ(2, r.headers.size());
+    EXPECT_EQ("Content-Length", r.headers[0].name);
+    EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+    EXPECT_EQ("Content-Type", r.headers[1].name);
+    EXPECT_EQ("text/plain", r.headers[1].value);
+
+    std::vector<boost::asio::const_buffer> buffers = r.to_buffers();
+
+    ASSERT_EQ(1 + r.headers.size() * 4 + 2, buffers.size());
+}
+
+
+TEST(ToStringTest, generaltest) {
+    Response r = Response::plain_text_response(
+        default_responses::to_string(Response::ResponseCode::ok));
+
+    ASSERT_EQ(Response::ResponseCode::ok, r.status);
+    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.content);
+    ASSERT_EQ(2, r.headers.size());
+    EXPECT_EQ("Content-Length", r.headers[0].name);
+    EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
+    EXPECT_EQ("Content-Type", r.headers[1].name);
+    EXPECT_EQ("text/plain", r.headers[1].value);
+
+
+    EXPECT_EQ("HTTP/1.0 200 OK\r\nContent-Length: 0\r\nContent-Type: text/plain\r\n\r\n", r.ToString());
+}
+

--- a/response_test.cc
+++ b/response_test.cc
@@ -8,13 +8,13 @@ protected:
     void VerifyContents(Response::ResponseCode status) {
         r = Response::default_response(status);
 
-        ASSERT_EQ(status, r.status);
-        ASSERT_EQ(default_responses::to_string(r.status), r.content);
-        ASSERT_EQ(2, r.headers.size());
-        EXPECT_EQ("Content-Length", r.headers[0].name);
-        EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
-        EXPECT_EQ("Content-Type", r.headers[1].name);
-        EXPECT_EQ("text/html", r.headers[1].value);
+        ASSERT_EQ(status, r.GetStatus());
+        ASSERT_EQ(default_responses::to_string(r.GetStatus()), r.GetBody());
+        ASSERT_EQ(2, r.GetHeaders().size());
+        EXPECT_EQ("Content-Length", r.GetHeaders()[0].name);
+        EXPECT_EQ(std::to_string(r.GetBody().size()), r.GetHeaders()[0].value);
+        EXPECT_EQ("Content-Type", r.GetHeaders()[1].name);
+        EXPECT_EQ("text/html", r.GetHeaders()[1].value);
     }
 
     Response r;
@@ -100,13 +100,13 @@ TEST(ResponseTest, html) {
     Response r = Response::html_response(
         default_responses::to_string(Response::ResponseCode::ok));
 
-    ASSERT_EQ(Response::ResponseCode::ok, r.status);
-    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.content);
-    ASSERT_EQ(2, r.headers.size());
-    EXPECT_EQ("Content-Length", r.headers[0].name);
-    EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
-    EXPECT_EQ("Content-Type", r.headers[1].name);
-    EXPECT_EQ("text/html", r.headers[1].value);
+    ASSERT_EQ(Response::ResponseCode::ok, r.GetStatus());
+    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.GetBody());
+    ASSERT_EQ(2, r.GetHeaders().size());
+    EXPECT_EQ("Content-Length", r.GetHeaders()[0].name);
+    EXPECT_EQ(std::to_string(r.GetBody().size()), r.GetHeaders()[0].value);
+    EXPECT_EQ("Content-Type", r.GetHeaders()[1].name);
+    EXPECT_EQ("text/html", r.GetHeaders()[1].value);
 }
 
 
@@ -114,13 +114,13 @@ TEST(ResponseTest, plain) {
     Response r = Response::plain_text_response(
         default_responses::to_string(Response::ResponseCode::ok));
 
-    ASSERT_EQ(Response::ResponseCode::ok, r.status);
-    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.content);
-    ASSERT_EQ(2, r.headers.size());
-    EXPECT_EQ("Content-Length", r.headers[0].name);
-    EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
-    EXPECT_EQ("Content-Type", r.headers[1].name);
-    EXPECT_EQ("text/plain", r.headers[1].value);
+    ASSERT_EQ(Response::ResponseCode::ok, r.GetStatus());
+    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.GetBody());
+    ASSERT_EQ(2, r.GetHeaders().size());
+    EXPECT_EQ("Content-Length", r.GetHeaders()[0].name);
+    EXPECT_EQ(std::to_string(r.GetBody().size()), r.GetHeaders()[0].value);
+    EXPECT_EQ("Content-Type", r.GetHeaders()[1].name);
+    EXPECT_EQ("text/plain", r.GetHeaders()[1].value);
 }
 
 
@@ -128,17 +128,17 @@ TEST(ToBufferTest, generaltest) {
     Response r = Response::plain_text_response(
         default_responses::to_string(Response::ResponseCode::ok));
 
-    ASSERT_EQ(Response::ResponseCode::ok, r.status);
-    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.content);
-    ASSERT_EQ(2, r.headers.size());
-    EXPECT_EQ("Content-Length", r.headers[0].name);
-    EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
-    EXPECT_EQ("Content-Type", r.headers[1].name);
-    EXPECT_EQ("text/plain", r.headers[1].value);
+    ASSERT_EQ(Response::ResponseCode::ok, r.GetStatus());
+    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.GetBody());
+    ASSERT_EQ(2, r.GetHeaders().size());
+    EXPECT_EQ("Content-Length", r.GetHeaders()[0].name);
+    EXPECT_EQ(std::to_string(r.GetBody().size()), r.GetHeaders()[0].value);
+    EXPECT_EQ("Content-Type", r.GetHeaders()[1].name);
+    EXPECT_EQ("text/plain", r.GetHeaders()[1].value);
 
     std::vector<boost::asio::const_buffer> buffers = r.to_buffers();
 
-    ASSERT_EQ(1 + r.headers.size() * 4 + 2, buffers.size());
+    ASSERT_EQ(1 + r.GetHeaders().size() * 4 + 2, buffers.size());
 }
 
 
@@ -146,13 +146,13 @@ TEST(ToStringTest, generaltest) {
     Response r = Response::plain_text_response(
         default_responses::to_string(Response::ResponseCode::ok));
 
-    ASSERT_EQ(Response::ResponseCode::ok, r.status);
-    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.content);
-    ASSERT_EQ(2, r.headers.size());
-    EXPECT_EQ("Content-Length", r.headers[0].name);
-    EXPECT_EQ(std::to_string(r.content.size()), r.headers[0].value);
-    EXPECT_EQ("Content-Type", r.headers[1].name);
-    EXPECT_EQ("text/plain", r.headers[1].value);
+    ASSERT_EQ(Response::ResponseCode::ok, r.GetStatus());
+    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.GetBody());
+    ASSERT_EQ(2, r.GetHeaders().size());
+    EXPECT_EQ("Content-Length", r.GetHeaders()[0].name);
+    EXPECT_EQ(std::to_string(r.GetBody().size()), r.GetHeaders()[0].value);
+    EXPECT_EQ("Content-Type", r.GetHeaders()[1].name);
+    EXPECT_EQ("text/plain", r.GetHeaders()[1].value);
 
 
     EXPECT_EQ("HTTP/1.0 200 OK\r\nContent-Length: 0\r\nContent-Type: text/plain\r\n\r\n", r.ToString());

--- a/response_test.cc
+++ b/response_test.cc
@@ -124,22 +124,7 @@ TEST(ResponseTest, plain) {
 }
 
 
-TEST(ToBufferTest, generaltest) {
-    Response r = Response::plain_text_response(
-        default_responses::to_string(Response::ResponseCode::ok));
 
-    ASSERT_EQ(Response::ResponseCode::ok, r.GetStatus());
-    ASSERT_EQ(default_responses::to_string(Response::ResponseCode::ok), r.GetBody());
-    ASSERT_EQ(2, r.GetHeaders().size());
-    EXPECT_EQ("Content-Length", r.GetHeaders()[0].name);
-    EXPECT_EQ(std::to_string(r.GetBody().size()), r.GetHeaders()[0].value);
-    EXPECT_EQ("Content-Type", r.GetHeaders()[1].name);
-    EXPECT_EQ("text/plain", r.GetHeaders()[1].value);
-
-    std::vector<boost::asio::const_buffer> buffers = r.to_buffers();
-
-    ASSERT_EQ(1 + r.GetHeaders().size() * 4 + 2, buffers.size());
-}
 
 
 TEST(ToStringTest, generaltest) {

--- a/response_test.cc
+++ b/response_test.cc
@@ -124,9 +124,6 @@ TEST(ResponseTest, plain) {
 }
 
 
-
-
-
 TEST(ToStringTest, generaltest) {
     Response r = Response::plain_text_response(
         default_responses::to_string(Response::ResponseCode::ok));

--- a/server.cc
+++ b/server.cc
@@ -80,8 +80,13 @@ void session::do_write(const http::response& res) {
     printf("==========\n\n");
 
     // Send the response back to the client and then we're done
-    boost::asio::async_write(socket, res.to_buffers(),
+    // boost::asio::async_write(socket, res.to_buffers(),
+    std::string res_string = res.ToString();
+    std::vector<boost::asio::const_buffer> testb;
+    testb.push_back(boost::asio::buffer(res_string, res_string.size()));
+    boost::asio::async_write(socket, boost::asio::buffer(res_string, res_string.size()),
         [this, self](boost::system::error_code ec, std::size_t len) {
+            printf("Amount of data written:%zu\n\n", len);
             if (ec) {
                 printf("Failed to send data to %s\n\n",
                     socket.remote_endpoint().address().to_string().c_str());

--- a/server.cc
+++ b/server.cc
@@ -79,11 +79,8 @@ void session::do_write(const Response& res) {
     printf("%s\n", request.as_string.c_str());
     printf("==========\n\n");
 
-    // Send the response back to the client and then we're done
-    // boost::asio::async_write(socket, res.to_buffers(),
+    // Send the response back to the client and then we're done   
     std::string res_string = res.ToString();
-    std::vector<boost::asio::const_buffer> testb;
-    testb.push_back(boost::asio::buffer(res_string, res_string.size()));
     boost::asio::async_write(socket, boost::asio::buffer(res_string, res_string.size()),
         [this, self](boost::system::error_code ec, std::size_t len) {
             printf("Amount of data written:%zu\n\n", len);

--- a/server.cc
+++ b/server.cc
@@ -54,11 +54,11 @@ void session::do_read() {
                     }
 
                     // If can't find match, return response not found
-                    do_write(http::response::default_response(http::response::not_found));
+                    do_write(Response::default_response(Response::not_found));
 
                 } else if (rslt == http::request_parser::bad) {
-                    do_write(http::response::default_response(
-                        http::response::bad_request));
+                    do_write(Response::default_response(
+                        Response::bad_request));
                 } else {
                     do_read();
                 }
@@ -68,7 +68,7 @@ void session::do_read() {
 
 
 // Callback for when a client should be written to
-void session::do_write(const http::response& res) {
+void session::do_write(const Response& res) {
     // Create a reference to "this" to ensure it outlives the async operation
     auto self(shared_from_this());
 

--- a/server.h
+++ b/server.h
@@ -8,7 +8,7 @@
 #include <boost/asio.hpp>
 #include "http_request.h"
 #include "http_request_parser.h"
-#include "http_response.h"
+#include "response.h"
 #include "http_handler_echo.h"
 #include "http_handler_file.h"
 
@@ -35,7 +35,7 @@ private:
     void do_read();
 
     // Callback for when a client should be written to
-    void do_write(const http::response& res);
+    void do_write(const Response& res);
 
     // Reference to the vector of request handlers
     const std::vector<std::unique_ptr<http::handler> >& handlers;

--- a/static_file_handler.cc
+++ b/static_file_handler.cc
@@ -1,0 +1,10 @@
+#include "static_file_handler.h"
+
+
+RequestHandler::Status StaticFileHandler::Init(const std::string& uri_prefix, const NginxConfig& config) {
+  std::cout << "StaticFileHandler::Init called" << std::endl;
+}
+
+RequestHandler::Status StaticFileHandler::HandleRequest(const Request& request, Response* response) {
+  std::cout << "StaticFileHandler::HandleRequest called" << std::endl;
+}

--- a/static_file_handler.cc
+++ b/static_file_handler.cc
@@ -3,8 +3,10 @@
 
 RequestHandler::Status StaticFileHandler::Init(const std::string& uri_prefix, const NginxConfig& config) {
   std::cout << "StaticFileHandler::Init called" << std::endl;
+  return RequestHandler::OK;
 }
 
 RequestHandler::Status StaticFileHandler::HandleRequest(const Request& request, Response* response) {
   std::cout << "StaticFileHandler::HandleRequest called" << std::endl;
+  return RequestHandler::OK;
 }

--- a/static_file_handler.h
+++ b/static_file_handler.h
@@ -1,0 +1,19 @@
+#ifndef STATIC_FILE_HANDLER_H
+#define STATIC_FILE_HANDLER_H
+
+#include "request_handler.h"
+#include <iostream>
+
+class StaticFileHandler : public RequestHandler {
+ public:
+    Status Init(const std::string& uri_prefix, const NginxConfig& config);
+
+    Status HandleRequest(const Request& request, Response* response);
+
+
+
+};
+
+REGISTER_REQUEST_HANDLER(StaticFileHandler);
+
+#endif  // STATIC_FILE_HANDLER_H


### PR DESCRIPTION
Skeleton code was added for the new api
- there is a new request, response, request_handler, static_file_handler, and echo_handler
- I have ported as best as I can the response file, everything currently using it
  - I added functions to get the private member variables instead of accessing directly
- skeleton code of request_handler and subclasses can be created by name
  -  registerer_example shows this in action
- new files exist separately from old files, need to be integrated to replace old files

Note: spacing and code consistency will be off since new api was spaced and named differently